### PR TITLE
スキーマ定義時の game.i18n 依存の解消と、TypedObjectField 見送りの記録

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,7 +7,7 @@
 エントリは `emoklore.ts`。`init` フックでDocumentクラス・DataModel・シート・ダイス関連を `CONFIG` に登録する。
 
 ```
-emoklore.ts          … エントリ。CONFIG登録、i18nInitでのラベルパッチ、開発用フック
+emoklore.ts          … エントリ。CONFIG登録、configのラベル事前ローカライズ、開発用フック
 module/
   config/            … 静的なゲームルール定義（技能・特性・共鳴感情など）→ CONFIG.EMOKLORE
   data/              … TypeDataModelスキーマ（character / npc / weapon）と派生値計算
@@ -22,7 +22,7 @@ lang/                … ja.json が正、en.json は追従
 
 ## 既知の構造的課題
 
-1. **スキーマ定義が `CONFIG.EMOKLORE` に依存**: `module/data/character.ts` がキー集合を得るために定義時点で `CONFIG.EMOKLORE` を読む。`TypedObjectField`（v14新フィールド型）で静的スキーマ + 動的キーに置き換えられないか要検討（既存データのマイグレーションが必要）
+1. **スキーマ定義が `CONFIG.EMOKLORE` に依存**: `module/data/character.ts` がキー集合を得るために定義時点で `CONFIG.EMOKLORE` を読む。`CONFIG.EMOKLORE` を設定するのは自分の `init` フックなので制御下にあるが、他モジュールが `init` 中に `Actor.dataModels.character.schema` へ触ると壊れうる。`TypedObjectField` での解消は検討したうえで見送った（下記）
 2. **NPCの扱いが未定**: `EmokloreActor` は `system` を `CharacterDataModel` として扱っており、判定やリソース操作をNPCに対して呼ぶと実行時に壊れる。NPC用シートの実装（Phase 3）で判定まわりごと決める
 3. **`config/` の副作用**: `module/config/index.ts` が import 時に `preLocalize` を呼び、`performPreLocalization` が `CONFIG.EMOKLORE` を破壊的に書き換える。この表の「`config/` に置かないもの」に反するが、dnd5e / draw-steel 由来の確立したパターンなので当面は踏襲する
 
@@ -30,7 +30,8 @@ Phase 2 で解消したもの:
 
 - ~~**Documentクラスの責務過多**~~: `rollSkill` / `rollResonance` の判定計算を `module/rules/`、ダイアログを `module/applications/dialogs/`、チャット生成を `module/utils/chat.ts` に分離した
 - ~~**プレゼンテーション層にルール計算**~~: `applications/helpers.ts` を責務ごとに `rules/character-points.ts` / `utils/sheet.ts` / `applications/helpers.ts` へ分割した
-- ~~**`i18nInit` からのスキーマパッチ**~~: config の複製だったラベルを保存するのをやめ、能力値ラベルは `LOCALIZATION_PREFIXES` と `ja.json` の `FIELDS` に載せた。`game.i18n` への定義時依存もなくなった
+- ~~**`i18nInit` からのスキーマパッチ**~~: config の複製だったラベルを保存するのをやめ、能力値ラベルは `LOCALIZATION_PREFIXES` と `ja.json` の `FIELDS` に載せた
+- ~~**スキーマ定義時の `game.i18n` 依存**~~: 能力値選択肢の `choices` に翻訳済み文字列を入れていたのをi18nキーに変えた。テンプレートが `formInput` に `localize=true` を渡しているため、描画時に本体が解決する
 - ~~**`as any` の多用**~~: 55箇所あったものをすべて解消し、`biome.json` の `noExplicitAny` を `error` にした。残る `any` は mixin のコンストラクタ制約1箇所のみで、理由コメント付きで個別抑制している
 - ~~**開発用ハックの混入**~~: `ready` フックのハードコードされたactor IDを `developerActorId` 設定に置き換えた
 
@@ -52,5 +53,28 @@ dnd5e の module 構成（applications / data / dice / documents / config / util
 
 - **判定ロジックは `rules/` の純粋関数に抽出**し、vitestで単体テスト可能にする。Foundry APIに依存しない形（入力: 技能レベル・修正値など、出力: formula・目標値・成功数）にする
 - **ダイアログ（判定オプション入力）はapplicationsに分離**し、Documentメソッドは「入力を集めて判定を実行し結果を流す」だけにする
-- **スキーマの動的生成をやめる方向を検討**: `CONFIG.EMOKLORE` に依存したスキーマ生成は、`TypedObjectField`（v14新フィールド型）などで静的なスキーマ + 動的キーに置き換えられないか検討する。ラベルのローカライズは `i18nInit` パッチではなく、Foundry標準の `LOCALIZATION_PREFIXES` / フィールド `label` の仕組みに寄せる
+- ラベルのローカライズは `i18nInit` パッチではなく、Foundry標準の `LOCALIZATION_PREFIXES` / フィールド `label` の仕組みに寄せる（対応済み）
 - リファクタリングは機能追加と混ぜず、**挙動を変えないコミット**を小さく積む
+
+## 検討して見送ったもの
+
+### `TypedObjectField` によるスキーマの静的化
+
+`CONFIG.EMOKLORE` への定義時依存を消す手段として検討したが、**見送った**。
+
+本体ソース（`common/data/fields.mjs`）を読んで確認した性質:
+
+- キーを自動生成しない。新規アクターの `skills` は `{}` から始まる
+- `element` は全キー共通。技能ごとに `initial` / `choices` / フィールドの有無を変えられない
+- 保存形は現在と同一なので、既存データのマイグレーションは不要
+
+見送りの理由は2つ目にある。現在のスキーマは技能ごとのルールを宣言的に持っており、シートがそれを直接読んで描画している。
+
+- `skill.field.fields.characteristic.choices` の有無で、能力値の select と静的表示を出し分けている
+- `skill.field.fields.specialization` の有無で、専門分野の入力欄を出し分けている
+
+`TypedObjectField` にするとこれらは表現できず、ルールが config 参照＋実行時コードへ散る。得られるのは定義時依存の解消だけで、その依存が起こす事故はまだ発生しておらず、`CONFIG.EMOKLORE` を設定するのは自分の `init` フックで制御下にある。
+
+より危険だった定義時の `game.i18n` 依存は、`choices` にi18nキーを入れる形に変えて別途解消した。
+
+再検討する価値があるのは、技能を**ユーザーが追加・削除できるようにする**場合。そのときは固定キーのスキーマ自体が成立しなくなるため、前提が変わる。

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -22,7 +22,7 @@ v14専用に移行します（v13サポートは打ち切り）。
 「動けばいい」で書いてきたコードを、適切な機能を適切な層に分離して責務をはっきりさせる形に書き換えます。設計方針と既知の課題は [アーキテクチャ](/architecture) を参照。
 
 - [x] スキーマ定義の初期化順序依存（`CONFIG.EMOKLORE` / `game.i18n`）の解消
-    - `game.i18n` への定義時依存と `i18nInit` からのパッチは解消。キー集合を得るための `CONFIG.EMOKLORE` 参照は残っており、`TypedObjectField` の採用で外せないか要検討
+    - `game.i18n` への定義時依存と `i18nInit` からのパッチは解消。キー集合を得るための `CONFIG.EMOKLORE` 参照は残るが、`TypedObjectField` での解消は検討のうえ見送った（理由は [アーキテクチャ](/architecture) の「検討して見送ったもの」）
 - [x] `EmokloreActor` から判定計算・ダイアログ・チャット生成を分離
 - [x] シート層に混ざったルール計算を data 層へ移動
 - [x] `as any` の削減（着手時55箇所 → 0。`noExplicitAny` を lint で `error` に）

--- a/module/data/character.ts
+++ b/module/data/character.ts
@@ -77,12 +77,15 @@ const defineCharacterDataModelSchema = () => {
           characteristic: new StringField({
             required: true,
             initial: characteristicOptions?.[0] ?? characteristic,
+            // choices の値は翻訳済み文字列ではなくi18nキーを入れる。テンプレートが
+            // formInput に localize=true を渡しており、描画時に本体が解決する。
+            // ここで localize すると、スキーマ定義時に game.i18n へ依存してしまう
             ...(characteristicOptions
               ? {
                   choices: Object.fromEntries(
                     characteristicOptions.map((key) => [
                       key,
-                      game.i18n.localize(`EMOKLORE.Actor.characteristics.${String(key)}`),
+                      `EMOKLORE.Actor.characteristics.${key}`,
                     ]),
                   ),
                 }


### PR DESCRIPTION
`TypedObjectField` への移行を検討した結果**見送り**、代わりに残っていた定義時の `game.i18n` 依存だけを解消する。

## 訂正

PR #12 で「`game.i18n` への定義時依存もなくなった」と書いたが、**誤りだった**。消したのは `skillGroups.label` と定義時 `label` の2つで、能力値選択肢の `choices` を組み立てる箇所を見落としていた。

```ts
choices: Object.fromEntries(
  characteristicOptions.map((key) => [
    key,
    game.i18n.localize(`EMOKLORE.Actor.characteristics.${String(key)}`),  // ← 残っていた
  ]),
),
```

`docs/architecture.md` と `docs/roadmap.md` にも誤った記述が入っていたので、あわせて訂正する。

## 修正

`choices` の値は翻訳済み文字列である必要がなく、**i18nキーをそのまま入れれば足りる**。テンプレートが既に `formInput` へ `localize=true` を渡しており、本体が描画時に解決する（`client/applications/forms/fields.mjs:313` の `if (config.localize) label = _loc(label)`）。

```hbs
{{formInput skill.field.fields.characteristic value=skill.characteristic localize=true}}
```

`choices` のキー側は変えていないので、バリデーションは従来どおり効く。

これで **data層から `game.i18n` の呼び出しがなくなった**。

## `TypedObjectField` を見送った理由

本体ソース（`common/data/fields.mjs`）を読んで性質を確認した。

| 事実 | 影響 |
|---|---|
| キーを自動生成しない（新規アクターは `skills: {}`） | 読み取り箇所すべてが「無い場合」を扱うか、`prepareBaseData` で補完が要る |
| `element` は全キー共通 | **技能ごとの `initial` / `choices` / フィールドの有無を表現できない** |
| 保存形は現在と同一 | 既存データのマイグレーションは**不要**（前回「必要」と述べたのは誤り） |

見送りの決め手は2つ目。現在のスキーマは技能ごとのルールを宣言的に持ち、**シートがそれを直接読んで描画している**。

```hbs
{{#if skill.field.fields.characteristic.choices}}   ← 能力値が選べる技能かどうか
{{#if skill.field.fields.specialization}}           ← 専門分野を持つ技能かどうか
```

`TypedObjectField` にするとこれらは表現できず、ルールが config 参照＋実行時コードへ散る。一方で得られるのは定義時の `CONFIG.EMOKLORE` 依存の解消だけで、

- その依存による事故はまだ起きていない
- `CONFIG.EMOKLORE` を設定するのは自分の `init` フックで制御下にある
- より危険だった `game.i18n` 依存は、このPRの1箇所の修正で解消する

割に合わないと判断した。判断と理由は `docs/architecture.md` に「検討して見送ったもの」として記録し、**技能をユーザーが追加・削除できるようにする場合は前提が変わる**ことも書き添えた。

## 動作確認

### 自動チェック

`npm run typecheck` / `npm test`（45件）/ `biome ci` / `npm run build` / `npm run check:lang` すべて通過。

### 実機検証（v14 build 365）

`choices` の表示と検証はテストで担保できないため実機で確認した。

| 確認項目 | 結果 |
|---|---|
| 選択肢の表示（14個のselect） | 「器用／五感」「五感／運勢」「精神／運勢」と日本語で表示される |
| 有効な値への変更 | `dexterity` → `sensitivity` に保存される |
| 選択肢外の値 | `fortune is not a valid choice` で拒否され、値は変わらない |
| コンソール | エラー・非推奨警告ともゼロ |

## ドキュメントの訂正内容

- `architecture.md` の「`game.i18n` への定義時依存もなくなった」を分離し、実際に解消した内容に書き換え
- 現状の構造図で `emoklore.ts` を「i18nInitでのラベルパッチ」と説明していたのを修正（PR #12 で削除済みだった）
- 「目指す層分離」の方針から、対応済みの `TypedObjectField` 検討項目を削除
- `roadmap.md` の初期化順序依存の注記を実態に合わせて更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)
