### PR TITLE
v13前提の記述を落とす

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,8 @@ npm run docs:build  # VitePressビルド
 
 ## 現在の開発フェーズ
 
-1. **v14対応**（次の作業）— 状況は `docs/v14-migration.md` の「作業状況」
-2. リファクタリング — `docs/architecture.md`
+本システムは**v14専用**（`system.json` の compatibility は `minimum: 14`）。v13サポートは打ち切り済みで、実機検証もv14で行う。
+
+1. ~~v14対応~~ — 完了（2026-07-19）。経緯と非推奨APIの備忘録は `docs/v14-migration.md`
+2. **リファクタリング**（現在）— `docs/architecture.md`
 3. 新機能 — `docs/roadmap.md`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,7 +11,7 @@
 ```
 https://github.com/ryotai-trpg/emoklore/releases/latest/download/system.json
 ```
-v13のみの対応です。v12以前への対応はしません。
+v14のみの対応です。v13以前への対応はしません。
 
 ## ダイスタス・コモンズ
 ◆表示：不要  


### PR DESCRIPTION
v13サポートは打ち切り済みで `system.json` の compatibility も `minimum: 14` になっているが、v13前提の記述が残っていた。

`docs/getting-started.md` はインストール要件が「v13のみの対応です」のままだった。利用者が最初に読むページなので実害が大きい。

`CLAUDE.md` の「現在の開発フェーズ」がv14対応を次の作業として挙げていたので、完了済みとして現在地をリファクタリングに更新した。

`docs/roadmap.md` と `docs/v14-migration.md` は既にv13打ち切りとPhase 1完了を記録しているので触っていない。

git管理外の `run-foundry` スキルと `CLAUDE.local.md` も、実機検証の既定環境をv14（dev-data-v14、ポート30014）に合わせて手元で更新した。これらはリポジトリに含まれないのでこのPRの差分には出ない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
