### PR TITLE
hbsでの翻訳キー組み立てをやめ、下の層に寄せる

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -32,11 +32,7 @@
         "effects": "Effects"
       },
       "fields": {
-        "specialization": "Specialization",
-        "skillName": "Skill Name",
-        "skillCharacteristic": "Characteristic",
-        "skillGroup": "Skill Group",
-        "isExtra": "Extra Skill"
+        "specialization": "Specialization"
       }
     },
     "SHEET.ToggleMode": "Toggle Play/Edit mode",
@@ -150,6 +146,24 @@
           "resources": {
             "hp": {
               "label": "HP",
+              "value": {
+                "label": "Current"
+              },
+              "max": {
+                "label": "Max"
+              }
+            },
+            "mp": {
+              "label": "MP",
+              "value": {
+                "label": "Current"
+              },
+              "max": {
+                "label": "Max"
+              }
+            },
+            "resonance": {
+              "label": "Resonance",
               "value": {
                 "label": "Current"
               },
@@ -275,9 +289,6 @@
         "strongLuck": "StrongLuck"
       }
     },
-    "baseSkill": "Base Skills",
-    "skill": "Skills",
-    "characteristics": "Characteristics",
     "skillRoll": "{skillName} Roll",
     "successMod": "Successes {mod}",
     "Effect": {

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -35,11 +35,7 @@
         "effects": "効果"
       },
       "fields": {
-        "specialization": "分野",
-        "skillName": "技能名",
-        "skillCharacteristic": "能力値",
-        "skillGroup": "グループ",
-        "isExtra": "EX技能"
+        "specialization": "分野"
       }
     },
     "SHEET.ToggleMode": "プレイ・編集モード切替",
@@ -166,6 +162,24 @@
               "max": {
                 "label": "最大"
               }
+            },
+            "mp": {
+              "label": "MP",
+              "value": {
+                "label": "現在"
+              },
+              "max": {
+                "label": "最大"
+              }
+            },
+            "resonance": {
+              "label": "共鳴",
+              "value": {
+                "label": "現在"
+              },
+              "max": {
+                "label": "最大"
+              }
             }
           },
 
@@ -286,9 +300,6 @@
         "strongLuck": "強運"
       }
     },
-    "baseSkill": "ベース技能",
-    "skill": "技能",
-    "characteristics": "能力値",
     "skillRoll": "〈{skillName}〉判定",
     "successMod": "成功数{mod}",
     "resonantEmotion": "{emotion}（{attribute}）",

--- a/module/applications/character-sheet.ts
+++ b/module/applications/character-sheet.ts
@@ -10,7 +10,7 @@ import {
 } from "../utils/sheet";
 import { EmokloreActorSheet } from "./actor-sheet";
 import { CharSheetImportDialog } from "./charsheet-import-dialog";
-import { createEmotionOptions, createSkillLevelOptions, getEmotionAttributes } from "./helpers";
+import { createEmotionOptions, createSkillLevelOptions, getEmotionRows } from "./helpers";
 import type {
   CharacterContext,
   CharacteristicsMap,
@@ -80,9 +80,10 @@ export class EmokloreCharacterSheet extends EmokloreActorSheet {
     const baseContext = await super._prepareContext(options);
     const context = baseContext as unknown as CharacterContext;
     context.config = CONFIG.EMOKLORE;
-    context.emotionAttributes = getEmotionAttributes(
+    context.emotionRows = getEmotionRows(
       context.system.emotions,
       context.config.resonantEmotions,
+      context.config.emotionAttributes,
     );
 
     context.emotionOptions = createEmotionOptions();

--- a/module/applications/character-sheet.ts
+++ b/module/applications/character-sheet.ts
@@ -1,3 +1,4 @@
+import type { CharacteristicKey } from "../config/characteristics";
 import { systemPath } from "../constants";
 import type { EmokloreActor } from "../documents/actor";
 import { calculateCharPointSum, calculateTotalSkillPoints } from "../rules/character-points";
@@ -159,6 +160,8 @@ export class EmokloreCharacterSheet extends EmokloreActorSheet {
    * 技能の表示用データ。
    *
    * label / isExtra はアクターに保存せず CONFIG.EMOKLORE 側の定義なので、ここで合流させる。
+   * 能力値ラベルも同様に引いておく。CONFIG の label は i18nInit の performPreLocalization で
+   * 翻訳済みなので、テンプレート側で言語キーを組み立てる必要はない。
    */
   _getSkills(): Record<string, unknown> {
     const data = this.actor;
@@ -167,11 +170,17 @@ export class EmokloreCharacterSheet extends EmokloreActorSheet {
         const value = foundry.utils.getProperty(data, `system.skills.${key}`) as
           | Record<string, unknown>
           | undefined;
+        const characteristic = value?.characteristic as CharacteristicKey | undefined;
         (obj as Record<string, unknown>)[key] = {
           field: this.actor.system.schema.getField(["skills", key]),
           label,
           isExtra: isExtra ?? false,
           ...(value ?? {}),
+          // spreadより後に置く。保存値には characteristicLabel がないので上書きされないが、
+          // 順序を変えると壊れる
+          characteristicLabel: characteristic
+            ? (CONFIG.EMOKLORE.characteristics[characteristic]?.label ?? "")
+            : "",
         };
         return obj;
       },

--- a/module/applications/helpers.test.ts
+++ b/module/applications/helpers.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import type { EmotionAttributesConfig } from "../config/emotion-attributes";
+import type { ResonantEmotionsConfig } from "../config/resonant-emotions";
+import { getEmotionRows } from "./helpers";
+
+// performPreLocalization 済みの CONFIG を模す。label は翻訳済みの文字列になっている
+const resonantEmotions: Record<string, ResonantEmotionsConfig> = {
+  possession: { label: "独占", attribute: "desire" },
+  hope: { label: "希望", attribute: "ideal" },
+};
+
+const emotionAttributes: Record<string, EmotionAttributesConfig> = {
+  desire: { label: "欲望" },
+  ideal: { label: "理想" },
+};
+
+const rowsFor = (emotions: Record<string, string | undefined>) =>
+  getEmotionRows(emotions, resonantEmotions, emotionAttributes);
+
+describe("getEmotionRows", () => {
+  it("感情名と属性名を翻訳済みの文字列で返す", () => {
+    const rows = rowsFor({ surface: "possession", hidden: "hope", root: "possession" });
+
+    expect(rows.surface).toEqual({ label: "独占", attribute: "欲望" });
+    expect(rows.hidden).toEqual({ label: "希望", attribute: "理想" });
+    expect(rows.root).toEqual({ label: "独占", attribute: "欲望" });
+  });
+
+  it("未選択の感情は空文字になる", () => {
+    const rows = rowsFor({ surface: "possession" });
+
+    expect(rows.hidden).toEqual({ label: "", attribute: "" });
+    expect(rows.root).toEqual({ label: "", attribute: "" });
+  });
+
+  // 以前は `EMOKLORE.emotionAttributes.` という尻切れの言語キーを組み立てており、
+  // それがそのままシートに表示されていた
+  it("既知でない感情が保存されていても言語キーを漏らさない", () => {
+    const rows = rowsFor({ surface: "unknownEmotion", hidden: "", root: undefined });
+
+    for (const row of [rows.surface, rows.hidden, rows.root]) {
+      expect(row).toEqual({ label: "", attribute: "" });
+    }
+  });
+
+  it("属性の定義が欠けていても感情名だけは返す", () => {
+    const rows = getEmotionRows({ surface: "possession" }, resonantEmotions, {});
+
+    expect(rows.surface).toEqual({ label: "独占", attribute: "" });
+  });
+
+  it("3つのキーを必ず埋める", () => {
+    expect(Object.keys(rowsFor({}))).toEqual(["surface", "hidden", "root"]);
+  });
+});

--- a/module/applications/helpers.ts
+++ b/module/applications/helpers.ts
@@ -1,8 +1,13 @@
+import type { EmotionAttributeKey, EmotionAttributesConfig } from "../config/emotion-attributes";
 import type { ResonantEmotionsConfig } from "../config/resonant-emotions";
+import type { EmotionKey, EmotionRow } from "./types";
+
 /**
  * シートのテンプレートに渡す選択肢やラベルを組み立てる。
  * ルール計算は module/rules/ に、DOM操作は module/utils/sheet.ts にある。
  */
+
+const EMOTION_KEYS: readonly EmotionKey[] = ["surface", "hidden", "root"];
 
 export const createSkillLevelOptions = (): Array<{ value: string; label: string }> => {
   return Object.entries(CONFIG.EMOKLORE.skillLevel).map(([value, { label }]) => ({
@@ -12,34 +17,44 @@ export const createSkillLevelOptions = (): Array<{ value: string; label: string 
 };
 
 export const createEmotionOptions = (): Array<{ value: string; label: string; group: string }> => {
-  return Object.entries(CONFIG.EMOKLORE.resonantEmotions).map(([value, { label, attribute }]) => ({
-    value: String(value),
-    label: game.i18n.localize("EMOKLORE.resonantEmotion", {
-      emotion: label,
-      attribute: game.i18n.localize(`EMOKLORE.emotionAttributes.${String(attribute)}`),
-    }),
-    group: game.i18n.localize(`EMOKLORE.emotionAttributes.${String(attribute)}`),
-  }));
+  return Object.entries(CONFIG.EMOKLORE.resonantEmotions).map(([value, { label, attribute }]) => {
+    const attributeLabel =
+      CONFIG.EMOKLORE.emotionAttributes[attribute as EmotionAttributeKey]?.label ?? "";
+    return {
+      value,
+      label: game.i18n.localize("EMOKLORE.resonantEmotion", {
+        emotion: label,
+        attribute: attributeLabel,
+      }),
+      group: attributeLabel,
+    };
+  });
 };
 
 /**
- * 共鳴感情に対応する属性の言語キーを引く。
+ * 共鳴感情の表示名と、対応する属性の表示名を引く。
  *
- * 未選択や、既知でない感情が保存されている場合は空文字を返す。以前は
- * `EMOKLORE.emotionAttributes.` という尻切れのキーを組み立てており、
- * それがシートにそのまま表示されていた。
+ * どちらの label も i18nInit の performPreLocalization で翻訳済みなので、ここでは
+ * 参照するだけでよい。以前は `EMOKLORE.emotionAttributes.` という言語キーを組み立てており、
+ * 感情が未選択のときに尻切れのキーがそのままシートに表示されていた。キーを作らない形に
+ * したので、未選択・未知の感情はどちらも空文字になる。
+ *
+ * game.i18n を呼ばない純粋関数なので、そのまま単体テストできる。
  */
-export const getEmotionAttributes = (
+export const getEmotionRows = (
   emotions: Record<string, string | undefined>,
   resonantEmotions: Record<string, ResonantEmotionsConfig>,
-): Record<string, string> => {
-  const emotionAttributes: Record<string, string> = {};
+  emotionAttributes: Record<string, EmotionAttributesConfig>,
+): Record<EmotionKey, EmotionRow> => {
+  const rows = {} as Record<EmotionKey, EmotionRow>;
 
-  for (const key of ["surface", "hidden", "root"]) {
+  for (const key of EMOTION_KEYS) {
     const emotionKey = emotions[key];
-    const attribute = emotionKey ? resonantEmotions[emotionKey]?.attribute : undefined;
-    emotionAttributes[key] = attribute ? `EMOKLORE.emotionAttributes.${attribute}` : "";
+    const emotion = emotionKey ? resonantEmotions[emotionKey] : undefined;
+    const attribute = emotion ? emotionAttributes[emotion.attribute] : undefined;
+
+    rows[key] = { label: emotion?.label ?? "", attribute: attribute?.label ?? "" };
   }
 
-  return emotionAttributes;
+  return rows;
 };

--- a/module/applications/types.ts
+++ b/module/applications/types.ts
@@ -16,6 +16,8 @@ export type EmokloreRenderOptions = HandlebarsRenderOptions & {
 export type SkillRow = {
   level: number;
   isExtra?: boolean;
+  /** 能力値の表示名。CONFIG.EMOKLORE から引いた翻訳済みの文字列 */
+  characteristicLabel: string;
   [key: string]: unknown;
 };
 

--- a/module/applications/types.ts
+++ b/module/applications/types.ts
@@ -6,6 +6,9 @@ import type { EmokloreActor } from "../documents/actor";
 // Common type definitions
 export type EmotionKey = "surface" | "hidden" | "root";
 
+/** 共鳴感情の表示用データ。どちらも翻訳済みの文字列で、未選択なら空文字 */
+export type EmotionRow = { label: string; attribute: string };
+
 // renderに独自オプション（mode等）を載せて受け渡すための型
 export type EmokloreRenderOptions = HandlebarsRenderOptions & {
   mode?: number;
@@ -89,7 +92,8 @@ export interface EmokloreDocumentSheetOptions {
 export type CharacterContext = {
   config: typeof CONFIG.EMOKLORE;
   system: CharacterDataModel;
-  emotionAttributes: Record<EmotionKey, string>;
+  // テンプレートが system.emotions も参照するので、紛れないよう emotionRows にしている
+  emotionRows: Record<EmotionKey, EmotionRow>;
   emotionOptions: Array<{ value: string; label: string; group: string }>;
   characteristics?: CharacteristicsMap;
   charPointSum?: number;

--- a/module/dice/emoklore-roll.ts
+++ b/module/dice/emoklore-roll.ts
@@ -54,6 +54,11 @@ export class EmokloreRoll extends foundry.dice.Roll {
     return resolveResultName(this.successCount);
   }
 
+  /** 判定結果の表示。チャットカードの見出しに出る「成功」「ダブル」など */
+  get resultLabel(): string {
+    return game.i18n.localize(`EMOKLORE.result.${this.resultName}`);
+  }
+
   /** 成功数修正の表示。修正がなければ空文字 */
   get successModLabel(): string {
     if (this.successMod === 0) return "";
@@ -86,7 +91,7 @@ export class EmokloreRoll extends foundry.dice.Roll {
     const baseContext = await super._prepareChatRenderContext(options);
     return {
       ...baseContext,
-      resultName: this.resultName,
+      resultLabel: this.resultLabel,
       dmFormula: this.dmFormula,
       successModLabel: this.successModLabel,
     };

--- a/templates/actor/effects.hbs
+++ b/templates/actor/effects.hbs
@@ -11,7 +11,7 @@
         data-effect-type='{{section.type}}'
       >
         <div class='effect-name'>
-          {{localize section.label}}
+          {{section.label}}
         </div>
         <div class='effect-source'>
           {{localize 'EMOKLORE.Effect.Source'}}

--- a/templates/actor/effects.hbs
+++ b/templates/actor/effects.hbs
@@ -55,7 +55,7 @@
               <a
                 class='effect-control'
                 data-action='toggleEffect'
-                data-tooltip='{{localize "EMOKLORE.Effect.Toggle"}}'
+                data-tooltip="EMOKLORE.Effect.Toggle"
               >
                 <i class='fas {{#if effect.disabled}}fa-check{{else}}fa-times{{/if}}'></i>
               </a>

--- a/templates/actor/header.hbs
+++ b/templates/actor/header.hbs
@@ -59,35 +59,17 @@
             <div class="value">
               Lv.{{formInput systemFields.resources.fields.resonance.fields.value value=system.resources.resonance.value}}
             </div>
-            <div>
-              {{#if system.emotions.surface}}
-              {{localize (concat "EMOKLORE.resonantEmotions." system.emotions.surface)}}
-              {{/if}}
-            </div>
+            <div>{{emotionRows.surface.label}}</div>
             <div class="small">
-              {{#if system.emotions.surface}}
-              （{{localize emotionAttributes.surface}}）
-              {{/if}}
+              {{#if emotionRows.surface.attribute}}（{{emotionRows.surface.attribute}}）{{/if}}
             </div>
-            <div>
-              {{#if system.emotions.hidden}}
-              {{localize (concat "EMOKLORE.resonantEmotions." system.emotions.hidden)}}
-              {{/if}}
-            </div>
+            <div>{{emotionRows.hidden.label}}</div>
             <div class="small">
-              {{#if system.emotions.hidden}}
-              （{{localize emotionAttributes.hidden}}）
-              {{/if}}
+              {{#if emotionRows.hidden.attribute}}（{{emotionRows.hidden.attribute}}）{{/if}}
             </div>
-            <div>
-              {{#if system.emotions.root}}
-              {{localize (concat "EMOKLORE.resonantEmotions." system.emotions.root)}}
-              {{/if}}
-            </div>
+            <div>{{emotionRows.root.label}}</div>
             <div class="small">
-              {{#if system.emotions.root}}
-              （{{localize emotionAttributes.root}}）
-              {{/if}}
+              {{#if emotionRows.root.attribute}}（{{emotionRows.root.attribute}}）{{/if}}
             </div>
           </div>
           <progress 

--- a/templates/actor/skills.hbs
+++ b/templates/actor/skills.hbs
@@ -25,7 +25,7 @@
     {{#if skill.field.fields.characteristic.choices}}
     <span class="characteristic">{{formInput skill.field.fields.characteristic value=skill.characteristic localize=true}}</span>
     {{else}}
-    <span class="characteristic">{{localize (concat "EMOKLORE.Actor.characteristics." skill.characteristic)}}</span>
+    <span class="characteristic">{{skill.characteristicLabel}}</span>
     {{/if}}
     {{#if skill.field.fields.specialization}}
     <span class="specialization">{{formInput skill.field.fields.specialization value=skill.specialization placeholder=(localize "EMOKLORE.CharacterSheet.fields.specialization")}}</span>

--- a/templates/rolls/skill.hbs
+++ b/templates/rolls/skill.hbs
@@ -8,6 +8,6 @@
       {{#if successModLabel}}<span class="success-mod">{{successModLabel}}</span>{{/if}}
     </div>
     {{{tooltip}}}
-    <h4 class="dice-total">{{localize (concat "EMOKLORE.result." resultName)}}</h4>
+    <h4 class="dice-total">{{resultLabel}}</h4>
   </div>
 </div>


### PR DESCRIPTION
## 背景

`templates/**/*.hbs` に `EMOKLORE.` で始まる言語キーが17箇所あり、うち4箇所は `{{localize (concat "EMOKLORE.Actor.characteristics." skill.characteristic)}}` のようにテンプレート内で文字列連結してキーを組み立てていた。言語ファイルの名前空間構造がプレゼンテーション層に漏れている。

問題は冗長さではない。`CONFIG.EMOKLORE` の `label` は `i18nInit` の `performPreLocalization` ですでに翻訳済みの文字列になっているのに、テンプレートが同じキーを組み立て直しており、同じラベルを作る処理が二重化していた。

`module/applications/helpers.ts` のコメントには、`EMOKLORE.emotionAttributes.` という尻切れのキーがシートにそのまま表示されていた過去のバグが記録されている。キーを実行時に組み立てる限り再発しうる。

`docs/architecture.md` の目指す層分離では `applications/` は「コンテキスト整形のみ」と定義されており、この整形はそこの責務にあたる。

## 変更

テンプレート内の言語キーは17箇所から12箇所に減り、動的なキー組み立ては4箇所から0箇所になった。後者が本質。

| 対象 | 変更前 | 変更後 |
|---|---|---|
| 能力値名 | `(concat "EMOKLORE.Actor.characteristics." skill.characteristic)` | `{{skill.characteristicLabel}}`（`_getSkills` が合流） |
| 共鳴感情 | `concat` とテンプレート側 `localize` の2段構え | `{{emotionRows.surface.label}}`（`getEmotionRows`） |
| 判定結果名 | `(concat "EMOKLORE.result." resultName)` | `{{resultLabel}}`（既存の `successModLabel` と同じ形） |
| ツールチップ | `data-tooltip='{{localize "EMOKLORE.Effect.Toggle"}}'` | `data-tooltip="EMOKLORE.Effect.Toggle"` |

`createEmotionOptions` もTS側で同じくキーを組み立てていたので、`CONFIG.EMOKLORE.emotionAttributes` を引く形に揃えた。

残した12箇所は静的な `{{localize "EMOKLORE.…"}}` で、これは変えていない。dnd5e / pf2e と同じ書き方で、翻訳者が全キーを grep できる利点がある。`{{t "Import.PasteJSON"}}` のような独自の短縮ヘルパーは導入しない判断をした。

## ついでに直したもの

`prepareActiveEffectCategories` が翻訳済みの文字列を返しているのにテンプレートが再度 `localize` をかけていたので外した。

参照のなくなっていた言語キー7つを削除した（`EMOKLORE.baseSkill` / `skill` / `characteristics` と、`CharacterSheet.fields` のうち `specialization` 以外の4つ）。

`FIELDS.resources` に `mp` と `resonance` を足した。スキーマには3つあるのに `hp` のラベルしか用意しておらず、ヘッダの `formInput` が本体のフォールバック表示になっていた。

## 触らなかったもの

`skills.hbs` の specialization の placeholder は `{{localize}}` のまま残した。`localizeSchema` は `placeholder` も `FIELDS` から引くが、パスが技能ごとになるため `hasSpecialization` の8技能 × ja/en で16エントリの重複になる。フィールド定義に生キーを置く手は使えない（本体がローカライズせずそのまま属性に流すため）。

`game.i18n.localize(key, data)` の5箇所は正しいので触っていない。v14で `Localization#format` が `localize(stringId, data)` に統合されており、`docs/v14-migration.md` に「今後も `format` は使わない」と方針が明記されている。

`ja.json` のキー命名の混在（PascalCase / camelCase、`SETTINGS.EMOKLORE` が `EMOKLORE` の外にある点）は差分が大きいので別途。

## 検証

`getEmotionRows` は `game.i18n` を呼ばない純粋関数なので、未選択・未知の感情でキーを漏らさないことをvitestで固定した。

lint / typecheck / test（58件）/ check:lang / check:templates / build はすべて通る。

実機（v14 build 365）で確認した。編集モードの能力値名が静的spanとドロップダウンの両方で正常、ヘッダに「所有（欲望）／希望（理想）／孤独（傷）」、チャットカードが6種の判定で正しい結果名、ツールチップ層が生キー `EMOKLORE.Effect.Toggle` を「切替」に解決することを確認した。

感情未選択のアクターを含め、2アクター × 2モード × 3タブを走査してキー漏れがゼロ、コンソールエラー・通知もゼロだった。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
