### PR TITLE
CSS・テンプレートの不具合修正

### DIFF
--- a/css/variable.css
+++ b/css/variable.css
@@ -2,6 +2,9 @@
    Emoklore CSS Variables
    =========================================== */
 
+/* 色はライトテーマの値を既定に置く。本体は prefers-color-scheme がライトでも
+   ダークでもない環境では body にテーマクラスを付けないため（client/game.mjs の
+   #configureTheme）、テーマ別ブロックだけに色を置くと変数が未定義になる */
 .emoklore {
   /* Layout Variables */
   --emoklore-sheet-sidebar-width: 250px;
@@ -10,6 +13,14 @@
   --emoklore-progress-radius: 5px;
   --emoklore-progress-radius-small: 2px;
   --emoklore-card-radius: 10px;
+
+  /* Colors */
+  --emoklore-accent-color: #42a5f5; /* Material Blue 400 */
+  --emoklore-darkgray: rgb(0 0 0 / 10%);
+  --emoklore-gray: rgb(0 0 0 / 20%);
+
+  --emoklore-green: #43a047; /* Material Green 600, HP color */
+  --emoklore-red: #e64a19; /* Material DeepOrange 700, MP color */
 }
 
 .theme-dark .emoklore,
@@ -20,14 +31,4 @@
 
   --emoklore-green: #388e3c; /* Material Green 700, HP color */
   --emoklore-red: #bf360c; /* Material DeepOrange 900, MP color */
-}
-
-.theme-light .emoklore,
-.emoklore.theme-light {
-  --emoklore-accent-color: #42a5f5; /* Material Blue 400 */
-  --emoklore-darkgray: rgb(0 0 0 / 10%);
-  --emoklore-gray: rgb(0 0 0 / 20%);
-
-  --emoklore-green: #43a047; /* Material Green 600, HP color */
-  --emoklore-red: #e64a19; /* Material DeepOrange 700, MP color */
 }

--- a/emoklore.css
+++ b/emoklore.css
@@ -580,31 +580,6 @@
     border: none;
   }
 
-  /* ===========================================
-   Character Sheet Import Dialog
-   =========================================== */
-
-  .charsheet-import-dialog {
-    textarea {
-      width: 100%;
-      font-family: monospace;
-      font-size: 12px;
-      resize: vertical;
-    }
-
-    .hint {
-      font-size: var(--font-size-12);
-      color: var(--color-text-dark-secondary);
-      margin: 0;
-    }
-
-    .form-footer {
-      justify-content: flex-end;
-      gap: 0.5rem;
-      margin-top: 1rem;
-    }
-  }
-
   /* Header Actions (Import Button) */
   .header-actions {
     display: flex;
@@ -627,6 +602,33 @@
         margin: 0;
       }
     }
+  }
+}
+
+/* ===========================================
+   Character Sheet Import Dialog
+   =========================================== */
+
+/* 取り込みダイアログはシートとは別のウィンドウなので、シートのブロックの中に
+   入れてはいけない。ルート要素が .emoklore.charsheet-import-dialog になる */
+.emoklore.charsheet-import-dialog {
+  textarea {
+    width: 100%;
+    font-family: monospace;
+    font-size: 12px;
+    resize: vertical;
+  }
+
+  .hint {
+    font-size: var(--font-size-12);
+    color: var(--color-text-dark-secondary);
+    margin: 0;
+  }
+
+  .form-footer {
+    justify-content: flex-end;
+    gap: 0.5rem;
+    margin-top: 1rem;
   }
 }
 

--- a/emoklore.css
+++ b/emoklore.css
@@ -13,11 +13,10 @@
    Theme Overrides
    =========================================== */
 
-.theme-dark .window-content {
-  padding-top: 0 !important;
-}
-
-.emoklore .application section.window-content {
+/* .application と .emoklore はシートのルート要素そのものに同居しているので、
+   .emoklore .application ... と書くと子孫結合子で自分自身に届かない。
+   .emoklore の子孫として .window-content を直接指す */
+.emoklore .window-content {
   padding-top: 0;
 }
 

--- a/emoklore.css
+++ b/emoklore.css
@@ -96,11 +96,6 @@
     border-radius: var(--emoklore-progress-radius);
   }
 
-  progress::-ms-fill {
-    background-color: var(--emoklore-accent-color);
-    border-radius: var(--emoklore-progress-radius);
-  }
-
   /* Resources Section */
   div.resources > div.bar > div > div > input[type="number"] {
     padding: 5px;
@@ -129,9 +124,6 @@
       progress::-moz-progress-bar {
         background-color: var(--emoklore-green);
       }
-      progress::-ms-fill {
-        background-color: var(--emoklore-green);
-      }
     }
 
     /* MP Bar */
@@ -143,9 +135,6 @@
         background-color: var(--emoklore-red);
       }
       progress::-moz-progress-bar {
-        background-color: var(--emoklore-red);
-      }
-      progress::-ms-fill {
         background-color: var(--emoklore-red);
       }
     }
@@ -243,12 +232,6 @@
     flex-direction: column;
   }
 
-  .emotions .play {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-around;
-  }
-
   /* Characteristics Section */
   .characteristics {
     display: flex;
@@ -291,9 +274,6 @@
     progress::-moz-progress-bar {
       border-radius: var(--emoklore-progress-radius-small);
     }
-    progress::-ms-fill {
-      border-radius: var(--emoklore-progress-radius-small);
-    }
   }
 
   /* Skills Section */
@@ -318,9 +298,6 @@
       border-radius: var(--emoklore-progress-radius-small);
     }
     progress::-moz-progress-bar {
-      border-radius: var(--emoklore-progress-radius-small);
-    }
-    progress::-ms-fill {
       border-radius: var(--emoklore-progress-radius-small);
     }
   }
@@ -426,16 +403,7 @@
       gap: 8px;
     }
 
-    .bio.stacked {
-      display: flex;
-      flex-direction: row;
-    }
-
     .biographies label {
-      color: var(--color-form-label);
-      font-weight: bold;
-    }
-    .biographies .label {
       color: var(--color-form-label);
       font-weight: bold;
     }
@@ -490,7 +458,6 @@
     padding: 0;
     overflow-y: auto;
     scrollbar-width: thin;
-    color: var(--boilerplate-c-tan);
   }
 
   .effects-list .effect-list {
@@ -500,7 +467,6 @@
   }
 
   .effects-list .effect-name {
-    flex: 2;
     margin: 0;
     overflow: hidden;
     font-size: 13px;
@@ -509,16 +475,8 @@
     display: flex;
   }
 
-  .effects-list .effect-name h3,
-  .effects-list .effect-name h4 {
-    margin: 0;
-    white-space: nowrap;
-    overflow-x: hidden;
-  }
-
   .effects-list .effect-controls {
     display: flex;
-    flex: 0 0 100px;
     justify-content: flex-end;
   }
 
@@ -531,15 +489,11 @@
   .effects-list .effect {
     align-items: center;
     padding: 0 2px;
-    border-bottom: 1px solid var(--boilerplate-c-faint);
+    border-bottom: 1px solid var(--emoklore-gray);
   }
 
   .effects-list .effect:last-child {
     border-bottom: none;
-  }
-
-  .effects-list .effect .effect-name {
-    color: var(--boilerplate-c-dark);
   }
 
   .effects-list .effect .effect-name .effect-image {
@@ -550,34 +504,9 @@
     margin-right: 5px;
   }
 
-  .effects-list .effect-prop {
-    text-align: center;
-    border-left: 1px solid #c9c7b8;
-    border-right: 1px solid #c9c7b8;
-    font-size: 12px;
-  }
-
   .effects-list .effects-header .effect-name {
     padding-left: 5px;
     text-align: left;
-  }
-
-  .effect-formula {
-    flex: 0 0 200px;
-    padding: 0 8px;
-  }
-
-  .effects .item .effect-source,
-  .effects .item .effect-duration,
-  .effects .item .effect-controls {
-    text-align: center;
-    border-left: 1px solid #c9c7b8;
-    border-right: 1px solid #c9c7b8;
-    font-size: 12px;
-  }
-
-  .effects .item .effect-controls {
-    border: none;
   }
 
   /* Header Actions (Import Button) */

--- a/emoklore.css
+++ b/emoklore.css
@@ -588,7 +588,7 @@
 
     button {
       padding: 0.25rem 0.5rem;
-      background: var(--color-cool-2);
+      background: var(--color-cool-4);
       border: 1px solid var(--color-border-dark-tertiary);
       border-radius: 3px;
       cursor: pointer;

--- a/lang/en.json
+++ b/lang/en.json
@@ -20,8 +20,10 @@
       }
     }
   },
-  "colon": ": ",
   "EMOKLORE": {
+    "Common": {
+      "colon": ": "
+    },
     "SheetClass": {
       "character": "Character Sheet"
     },

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -22,9 +22,10 @@
     }
   },
 
-  "colon": "：",
-
   "EMOKLORE": {
+    "Common": {
+      "colon": "："
+    },
     "SheetClass": {
       "character": "キャラクターシート"
     },

--- a/module/applications/actor-sheet.ts
+++ b/module/applications/actor-sheet.ts
@@ -13,22 +13,8 @@ export class EmokloreActorSheet extends EmokloreDocumentSheetMixin(
     classes: ["actor"],
     actions: {
       roll: this.#onRoll,
-      increaseResources: this.#onIncreaseResources,
-      decreaseResources: this.#onDecreaseResources,
     },
   };
-
-  static async #onIncreaseResources(this: EmokloreActorSheet, event: Event, target: HTMLElement) {
-    event.preventDefault();
-    const dataset = (target as HTMLElement & { dataset: DOMStringMap }).dataset;
-    return this.actor.adjustResource(dataset.type as "hp" | "mp" | "resonance", 1);
-  }
-
-  static async #onDecreaseResources(this: EmokloreActorSheet, event: Event, target: HTMLElement) {
-    event.preventDefault();
-    const dataset = (target as HTMLElement & { dataset: DOMStringMap }).dataset;
-    return this.actor.adjustResource(dataset.type as "hp" | "mp" | "resonance", -1);
-  }
 
   static async #onRoll(this: EmokloreActorSheet, event: Event, target: HTMLElement) {
     event.preventDefault();

--- a/module/applications/character-sheet.ts
+++ b/module/applications/character-sheet.ts
@@ -102,7 +102,7 @@ export class EmokloreCharacterSheet extends EmokloreActorSheet {
         this._prepareSkillsContext(context);
         break;
       case "biography":
-        this._prepareBiographyContext(context);
+        await this._prepareBiographyContext(context);
         break;
       case "effects":
         this._prepareEffectsContext(context);
@@ -197,8 +197,19 @@ export class EmokloreCharacterSheet extends EmokloreActorSheet {
     context.skillLevelOptions = createSkillLevelOptions();
   }
 
-  private _prepareBiographyContext(_context: CharacterContext): void {
-    // Add biography-specific processing here if needed
+  /**
+   * 経歴の備考は system.json で htmlFields に指定しているリッチテキスト。
+   * @UUID リンクやインラインロールを解決するため、描画前に enrichHTML を通す。
+   */
+  private async _prepareBiographyContext(context: CharacterContext): Promise<void> {
+    context.noteHTML = await foundry.applications.ux.TextEditor.implementation.enrichHTML(
+      this.actor.system.biography.note,
+      {
+        secrets: this.actor.isOwner,
+        relativeTo: this.actor,
+        rollData: this.actor.getRollData(),
+      },
+    );
   }
 
   private _prepareEffectsContext(context: CharacterContext): void {

--- a/module/applications/charsheet-import-dialog.ts
+++ b/module/applications/charsheet-import-dialog.ts
@@ -17,6 +17,9 @@ export class CharSheetImportDialog extends foundry.applications.api.HandlebarsAp
 ) {
   static override DEFAULT_OPTIONS = {
     id: "charsheet-import-{id}",
+    // emoklore は変数の定義スコープ、charsheet-import-dialog はこのダイアログの
+    // スタイルのスコープ。どちらもルート要素に付く
+    classes: ["emoklore", "charsheet-import-dialog"],
     tag: "form",
     form: {
       handler: CharSheetImportDialog.onSubmit,

--- a/module/applications/types.ts
+++ b/module/applications/types.ts
@@ -31,8 +31,6 @@ export type CharacteristicsMap = Record<
 
 export type EmokloreActorSheetActions = {
   roll: (event: Event, target: HTMLElement) => Promise<unknown>;
-  increaseResources: (event: Event, target: HTMLElement) => Promise<unknown>;
-  decreaseResources: (event: Event, target: HTMLElement) => Promise<unknown>;
   // mixin側のDEFAULT_OPTIONSから継承チェーン経由でマージされるので、各シートでの宣言は任意
   toggleMode?: (event: Event, target: HTMLElement) => Promise<void>;
 };
@@ -121,8 +119,6 @@ export type EmokloreCharacterSheetActions = {
   deleteDoc: (event: Event, target: HTMLElement) => Promise<void>;
   toggleEffect: (event: Event, target: HTMLElement) => Promise<void>;
   roll: (event: Event, target: HTMLElement) => Promise<unknown>;
-  increaseResources: (event: Event, target: HTMLElement) => Promise<unknown>;
-  decreaseResources: (event: Event, target: HTMLElement) => Promise<unknown>;
   // mixin側のDEFAULT_OPTIONSから継承チェーン経由でマージされるので、各シートでの宣言は任意
   toggleMode?: (event: Event, target: HTMLElement) => Promise<void>;
 };

--- a/module/applications/types.ts
+++ b/module/applications/types.ts
@@ -100,6 +100,8 @@ export type CharacterContext = {
   skills?: Record<string, SkillRow>;
   skillPointSum?: number;
   skillLevelOptions?: Array<{ value: string; label: string }>;
+  // 経歴の備考を enrichHTML に通した結果。生の system.biography.note とは別に持つ
+  noteHTML?: string;
   tabs: Record<string, ApplicationTab>;
   tab?: unknown;
   effects?: ReturnType<typeof import("../utils/effects").prepareActiveEffectCategories>;

--- a/module/documents/actor.ts
+++ b/module/documents/actor.ts
@@ -28,6 +28,7 @@ export class EmokloreActor extends Actor {
   declare effects: foundry.utils.Collection<string, foundry.documents.ActiveEffect>;
   // sheet は ClientDocumentMixin 由来でジェネリクスが消えている
   declare sheet: { render: (force?: boolean) => void } | null;
+  declare isOwner: boolean;
 
   override getRollData(): Record<string, unknown> {
     const rollData = { ...this.system, flags: this.flags, name: this.name };

--- a/module/documents/actor.ts
+++ b/module/documents/actor.ts
@@ -102,7 +102,9 @@ function formatSkillName(
   { base }: { base: boolean },
 ): string {
   const prefix = base ? "＊" : isExtra ? "★" : "";
-  const suffix = specialization ? `${game.i18n.localize("colon")}${specialization}` : "";
+  const suffix = specialization
+    ? `${game.i18n.localize("EMOKLORE.Common.colon")}${specialization}`
+    : "";
 
   return `${prefix}${label}${suffix}`;
 }

--- a/templates/actor/biography.hbs
+++ b/templates/actor/biography.hbs
@@ -45,7 +45,7 @@
     </div>
     <div class="bio">
       <label>{{systemFields.biography.fields.note.label}}</label>
-      <span class="value">{{{system.biography.note}}}</span>
+      <span class="value">{{{noteHTML}}}</span>
     </div>
 
     {{else}}

--- a/templates/actor/card-edit.hbs
+++ b/templates/actor/card-edit.hbs
@@ -19,7 +19,4 @@
       {{/each}}
     </div>
   </div>
-
-  <div>
-  </div>
 </div>

--- a/templates/actor/card-view.hbs
+++ b/templates/actor/card-view.hbs
@@ -13,7 +13,4 @@
       {{/each}}
     </div>
   </div>
-
-  <div>
-  </div>
 </div>

--- a/templates/actor/header.hbs
+++ b/templates/actor/header.hbs
@@ -1,102 +1,99 @@
 {{! Sheet Header }}
-<div>
-  <header class="sheet-header">
-    <div class="container">
-      <div class="name">
-        {{#if isPlay}}
-        {{source.name}}
-        {{else}}
-        {{formInput fields.name value=source.name placeholder=(localize "DOCUMENT.FIELDS.name.label")
-        aria=(object label=(localize "DOCUMENT.FIELDS.name.label"))}}
-        {{/if}}
-      </div>
-
-      {{#unless isPlay}}
-      <div class="header-actions">
-        <button type="button" data-action="importCharacter" data-tooltip="EMOKLORE.Import.ImportTooltip">
-          <i class="fa-solid fa-file-import"></i>
-        </button>
-      </div>
-      {{/unless}}
-
+<header class="sheet-header">
+  <div class="container">
+    <div class="name">
       {{#if isPlay}}
-      <div class="resources">
-        <div class="hp bar">
-
-          <div class="info">
-            <i class="fa-solid fa-heart label"></i>
-            <div class="value">
-              {{formInput systemFields.resources.fields.hp.fields.value value=system.resources.hp.value}}
-              <span class="small">/{{ system.resources.hp.max }}</span>
-            </div>
-          </div>
-
-          <progress 
-            id="character-hp"
-            value="{{ system.resources.hp.value }}" 
-            max="{{ system.resources.hp.max }}"
-            ></progress>
-        </div>
-
-        <div class="mp bar">
-          <div class="info">
-            <i class="fa-solid fa-wand-magic-sparkles label"></i>
-            <div class="value">
-              {{formInput systemFields.resources.fields.mp.fields.value value=system.resources.mp.value}}
-              <span class="small">/{{ system.resources.mp.max }}</span>
-            </div>
-          </div>
-          <progress 
-            id="character-mp"
-            value="{{ system.resources.mp.value }}" 
-            max="{{ system.resources.mp.max }}"
-            ></progress>
-        </div>
-
-        <div class="resonance bar">
-          <div class="info">
-            <button type="button" class="inline-control icon fa-solid fa-infinity" data-action="roll" data-roll-type="resonance"></button>
-            <div class="value">
-              Lv.{{formInput systemFields.resources.fields.resonance.fields.value value=system.resources.resonance.value}}
-            </div>
-            <div>{{emotionRows.surface.label}}</div>
-            <div class="small">
-              {{#if emotionRows.surface.attribute}}（{{emotionRows.surface.attribute}}）{{/if}}
-            </div>
-            <div>{{emotionRows.hidden.label}}</div>
-            <div class="small">
-              {{#if emotionRows.hidden.attribute}}（{{emotionRows.hidden.attribute}}）{{/if}}
-            </div>
-            <div>{{emotionRows.root.label}}</div>
-            <div class="small">
-              {{#if emotionRows.root.attribute}}（{{emotionRows.root.attribute}}）{{/if}}
-            </div>
-          </div>
-          <progress 
-            id="character-resonance"
-            value="{{ system.resources.resonance.value }}" 
-            max="{{ system.resources.resonance.max }}" 
-            ></progress>
-        </div>
-      </div>
+      {{source.name}}
       {{else}}
-      <div class="emotions">
-        {{formGroup
-        systemFields.emotions.fields.surface
-        value=system.emotions.surface
-        options=emotionOptions
-        }}
-        {{formGroup
-        systemFields.emotions.fields.hidden
-        value=system.emotions.hidden
-        options=emotionOptions
-        }}
-        {{formGroup
-        systemFields.emotions.fields.root
-        value=system.emotions.root
-        options=emotionOptions
-        }}
-      </div>
+      {{formInput fields.name value=source.name placeholder=(localize "DOCUMENT.FIELDS.name.label")
+      aria=(object label=(localize "DOCUMENT.FIELDS.name.label"))}}
       {{/if}}
-  </header>
     </div>
+
+    {{#unless isPlay}}
+    <div class="header-actions">
+      <button type="button" data-action="importCharacter" data-tooltip="EMOKLORE.Import.ImportTooltip">
+        <i class="fa-solid fa-file-import"></i>
+      </button>
+    </div>
+    {{/unless}}
+
+    {{#if isPlay}}
+    <div class="resources">
+      <div class="hp bar">
+        <div class="info">
+          <i class="fa-solid fa-heart label"></i>
+          <div class="value">
+            {{formInput systemFields.resources.fields.hp.fields.value value=system.resources.hp.value}}
+            <span class="small">/{{ system.resources.hp.max }}</span>
+          </div>
+        </div>
+        <progress
+          id="character-hp"
+          value="{{ system.resources.hp.value }}"
+          max="{{ system.resources.hp.max }}"
+          ></progress>
+      </div>
+
+      <div class="mp bar">
+        <div class="info">
+          <i class="fa-solid fa-wand-magic-sparkles label"></i>
+          <div class="value">
+            {{formInput systemFields.resources.fields.mp.fields.value value=system.resources.mp.value}}
+            <span class="small">/{{ system.resources.mp.max }}</span>
+          </div>
+        </div>
+        <progress
+          id="character-mp"
+          value="{{ system.resources.mp.value }}"
+          max="{{ system.resources.mp.max }}"
+          ></progress>
+      </div>
+
+      <div class="resonance bar">
+        <div class="info">
+          <button type="button" class="inline-control icon fa-solid fa-infinity" data-action="roll" data-roll-type="resonance"></button>
+          <div class="value">
+            Lv.{{formInput systemFields.resources.fields.resonance.fields.value value=system.resources.resonance.value}}
+          </div>
+          <div>{{emotionRows.surface.label}}</div>
+          <div class="small">
+            {{#if emotionRows.surface.attribute}}（{{emotionRows.surface.attribute}}）{{/if}}
+          </div>
+          <div>{{emotionRows.hidden.label}}</div>
+          <div class="small">
+            {{#if emotionRows.hidden.attribute}}（{{emotionRows.hidden.attribute}}）{{/if}}
+          </div>
+          <div>{{emotionRows.root.label}}</div>
+          <div class="small">
+            {{#if emotionRows.root.attribute}}（{{emotionRows.root.attribute}}）{{/if}}
+          </div>
+        </div>
+        <progress
+          id="character-resonance"
+          value="{{ system.resources.resonance.value }}"
+          max="{{ system.resources.resonance.max }}"
+          ></progress>
+      </div>
+    </div>
+    {{else}}
+    <div class="emotions">
+      {{formGroup
+      systemFields.emotions.fields.surface
+      value=system.emotions.surface
+      options=emotionOptions
+      }}
+      {{formGroup
+      systemFields.emotions.fields.hidden
+      value=system.emotions.hidden
+      options=emotionOptions
+      }}
+      {{formGroup
+      systemFields.emotions.fields.root
+      value=system.emotions.root
+      options=emotionOptions
+      }}
+    </div>
+    {{/if}}
+  </div>
+</header>

--- a/templates/actor/skills.hbs
+++ b/templates/actor/skills.hbs
@@ -9,7 +9,7 @@
   {{#if skill.level}}
   <div class="skill play" data-skill="{{key}}">
     <a class="label" data-action="roll" data-roll-type="skill" data-skill="{{key}}">
-      {{skill.label}}{{#if skill.specialization}}{{localize "colon"}}{{skill.specialization}}{{/if}}
+      {{skill.label}}{{#if skill.specialization}}{{localize "EMOKLORE.Common.colon"}}{{skill.specialization}}{{/if}}
     </a>
     <span>Lv.{{skill.level}}</span>
     <progress value="{{skill.level}}" max="3"></progress>


### PR DESCRIPTION
CSSとhbsのリファクタリングに着手する前に、調査で見つかった実際に壊れている箇所を先に潰す。リファクタと混ざると原因の切り分けができなくなるため、挙動の是正だけをこのPRにまとめた。

## 直したもの

### グローバル汚染（#3）

`.theme-dark .window-content { padding-top: 0 !important }` がシステムのスコープの外にあり、ダークテーマのとき Foundry の全アプリケーションから上の余白を消していた。サイドバーも設定画面も他システムのシートも巻き込んでいる。

ライトテーマ版のつもりで書かれていた `.emoklore .application section.window-content` は、`.application` と `.emoklore` がシートのルート要素に同居しているため子孫結合子では自分自身に届かず、一度も効いていなかった。テーマによって余白が違って見えていたのはこれが理由。

`.emoklore .window-content` の1本にまとめた。ライトテーマでも余白が詰まるようになる。

### 取り込みダイアログのスタイルが丸ごと死んでいた（#5）

`.charsheet-import-dialog` のブロックが `.emoklore.sheet.character` の内側にネストされていた。取り込みダイアログはシートとは別の独立したウィンドウでシートのクラスがどれも付かないため、textarea の幅も hint の色もフッタの配置も一度も適用されていない。

ブロックをシートの外に出し、ダイアログのルート要素にクラスを付けて届くようにした。

### 経歴の備考が enrichHTML を通っていなかった（#2）

`system.json` で `biography.note` を `htmlFields` に指定しているのに、経歴タブのコンテキスト整形が空実装で保存値をそのまま出力していた。`@UUID` リンクもインラインロールもシークレットブロックも機能していない。

### 存在しない変数・未定義の変数（#6, #7）

`--color-cool-2` はv14の本体に定義がない（cool-3/4/5 のみ）。取り込みボタンの通常時の背景が描かれず、hover のときだけ背景が出る状態だった。

`--boilerplate-c-tan` / `-faint` / `-dark` は Boilerplate システムからのコピー残骸で、このリポジトリのどこにも定義がない。エフェクト一覧の区切り線と文字色が落ちていた。区切り線は見せる意図があったので `--emoklore-gray` に置き換え、文字色はテーマの既定に任せて宣言ごと削除した。

### HTML構造の不整合（#1）

`header.hbs` が `.container` の div を開いたまま `header` を先に閉じており、閉じ div の数も1つ足りなかった。ブラウザの自動補正で表示は成立していたが、`.sheet-header .container` のスタイルが意図した箱に掛かっている保証がない状態だった。

### テーマクラスが付かないとき色が落ちる（#4）

本体の `#configureTheme` は `prefers-color-scheme` がライトともダークとも判定されない環境では body にテーマクラスを付けない。色の変数をテーマ別ブロックだけに置いていたため、この場合にバーの色が未定義になる。ライトの値を既定に移し、ダークだけが上書きする形にした。

### デッドコードの削除（#7, #8）

到達不能なセレクタ（`.effects .item ...` / `.effect-prop` / `.effect-formula` / `.emotions .play` / `.bio.stacked` など）、グリッドアイテムに対する無視される `flex` 指定、旧Edge専用で Chromium にも Firefox にも効かない `progress::-ms-fill` を削除した。

テンプレートに `data-action` が存在せず呼ばれる経路のない `increaseResources` / `decreaseResources` も外した。`EmokloreActor.adjustResource` はマクロから呼べるドキュメント側のAPIなので残している。

### i18nキーの名前空間（#9）

区切り文字を `colon` というトップレベルのキーで持っていた。言語ファイルのキーはグローバルなので、他のシステムやモジュールが同じ名前を定義すると壊れる。`EMOKLORE.Common.colon` に移した。

## 見た目が変わるところ

- ライトテーマでもシートの上の余白が詰まる
- 他のアプリケーションの余白が本体の既定に戻る
- 取り込みダイアログのスタイルが効くようになる
- 取り込みボタンに通常時の背景が付く
- エフェクト一覧の行に区切り線が出る
- 経歴の備考のリンクとインラインロールが機能する

## 確認

`npm run typecheck` / `lint` / `check:lang` / `check:templates` / `test` / `build` すべて通過。実機での目視確認はこれから。