### PR TITLE
prepareDerivedData のルール計算を rules/ へ抽出し、as unknown as を解消

### DIFF
--- a/module/applications/character-sheet.ts
+++ b/module/applications/character-sheet.ts
@@ -1,4 +1,5 @@
 import type { CharacteristicKey } from "../config/characteristics";
+import type { SkillKey } from "../config/skills";
 import { systemPath } from "../constants";
 import type { EmokloreActor } from "../documents/actor";
 import {
@@ -26,6 +27,7 @@ import type {
   CharacterContext,
   CharacteristicsMap,
   EmokloreRenderOptions,
+  LabeledField,
   SkillRow,
 } from "./types";
 
@@ -101,7 +103,7 @@ export class EmokloreCharacterSheet extends EmokloreActorSheet {
     // 基底のコンテキストはドキュメント種別を問わない形なので、
     // characterシートであることが分かっているここで1回だけ絞る
     const baseContext = await super._prepareContext(options);
-    const context = baseContext as unknown as CharacterContext;
+    const context = baseContext as CharacterContext;
     context.config = CONFIG.EMOKLORE;
     context.emotionRows = getEmotionRows(
       context.system.emotions,
@@ -171,19 +173,16 @@ export class EmokloreCharacterSheet extends EmokloreActorSheet {
    * アイコンは CONFIG.EMOKLORE 側の定義なので、テンプレートで二重の lookup を
    * 組まずに済むようここで引いておく。
    */
-  _getCharacteristics(): Record<string, unknown> {
-    const data = this.actor;
-    return Object.entries(CONFIG.EMOKLORE.characteristics).reduce(
-      (obj, [chc, { fa }]) => {
-        const value = foundry.utils.getProperty(data, `system.characteristics.${chc}.value`);
-        (obj as Record<string, unknown>)[chc] = {
+  _getCharacteristics(): CharacteristicsMap {
+    return Object.fromEntries(
+      Object.entries(CONFIG.EMOKLORE.characteristics).map(([chc, { fa }]) => [
+        chc,
+        {
           field: this.actor.system.schema.getField(["characteristics", chc]),
-          value: value ?? 0,
+          value: this.actor.system.characteristics[chc as CharacteristicKey]?.value ?? 0,
           icon: fa,
-        };
-        return obj;
-      },
-      {} as Record<string, unknown>,
+        },
+      ]),
     );
   }
 
@@ -194,31 +193,27 @@ export class EmokloreCharacterSheet extends EmokloreActorSheet {
    * 能力値ラベルも同様に引いておく。CONFIG の label は i18nInit の performPreLocalization で
    * 翻訳済みなので、テンプレート側で言語キーを組み立てる必要はない。
    */
-  _getSkills(): Record<string, unknown> {
-    const data = this.actor;
-    return Object.entries(CONFIG.EMOKLORE.skills).reduce(
-      (obj, [key, { label, isExtra }]) => {
-        const value = foundry.utils.getProperty(data, `system.skills.${key}`) as
-          | Record<string, unknown>
-          | undefined;
-        const characteristic = value?.characteristic as CharacteristicKey | undefined;
-        (obj as Record<string, unknown>)[key] = {
-          field: this.actor.system.schema.getField(["skills", key]),
-          label,
-          isExtra: isExtra ?? false,
-          ...(value ?? {}),
-          // spreadより後に置く。保存値には characteristicLabel がないので上書きされないが、
-          // 順序を変えると壊れる
-          characteristicLabel: characteristic
-            ? (CONFIG.EMOKLORE.characteristics[characteristic]?.label ?? "")
-            : "",
-          characteristicIcon: characteristic
-            ? (CONFIG.EMOKLORE.characteristics[characteristic]?.fa ?? "")
-            : "",
-        };
-        return obj;
-      },
-      {} as Record<string, unknown>,
+  _getSkills(): Record<string, SkillRow> {
+    return Object.fromEntries(
+      Object.entries(CONFIG.EMOKLORE.skills).map(([key, { label, isExtra }]) => {
+        const entry = this.actor.system.skills[key as SkillKey];
+        const characteristic = CONFIG.EMOKLORE.characteristics[entry.characteristic];
+        return [
+          key,
+          {
+            field: this.actor.system.schema.getField(["skills", key]),
+            label,
+            isExtra: isExtra ?? false,
+            level: entry.level,
+            target: entry.target,
+            characteristic: entry.characteristic,
+            specialization: entry.specialization,
+            mod: entry.mod,
+            characteristicLabel: characteristic?.label ?? "",
+            characteristicIcon: characteristic?.fa ?? "",
+          },
+        ];
+      }),
     );
   }
 
@@ -240,10 +235,10 @@ export class EmokloreCharacterSheet extends EmokloreActorSheet {
   }
 
   private _prepareSkillsContext(context: CharacterContext): void {
-    context.characteristics = this._getCharacteristics() as unknown as CharacteristicsMap;
+    context.characteristics = this._getCharacteristics();
     context.charPointSum = calculateCharPointSum(context.characteristics);
     context.charPointMax = CHARACTERISTIC_POINT_MAX;
-    context.skills = this._getSkills() as unknown as Record<string, SkillRow>;
+    context.skills = this._getSkills();
     context.skillPointSum = this._calculateSkillPointSumFromContext(context.skills);
     context.skillPointMax = SKILL_POINT_MAX;
     context.baseSkills = this._getBaseSkills();
@@ -271,8 +266,8 @@ export class EmokloreCharacterSheet extends EmokloreActorSheet {
     ]) as foundry.data.fields.SchemaField;
 
     const rows = buildBiographyRows(
-      biography.fields as unknown as Record<string, { label?: string }>,
-      this.actor.system.biography as unknown as Record<string, string>,
+      biography.fields as Record<string, LabeledField>,
+      this.actor.system.biography,
       { note: noteHTML },
     );
 
@@ -287,7 +282,7 @@ export class EmokloreCharacterSheet extends EmokloreActorSheet {
   }
 
   private _calculateSkillPointSumFromContext(skills: Record<string, SkillRow>): number {
-    const skillsObject = Object.values(skills) as Array<{ level: number; isExtra?: boolean }>;
+    const skillsObject = Object.values(skills);
     const exSkillsObject = skillsObject.filter((skill) => skill.isExtra);
     return calculateTotalSkillPoints(skillsObject, exSkillsObject);
   }

--- a/module/applications/helpers.ts
+++ b/module/applications/helpers.ts
@@ -44,7 +44,8 @@ export const BIOGRAPHY_PAIRED_COUNT = 2;
  */
 export const buildBiographyRows = (
   fields: Record<string, { label?: string }>,
-  values: Record<string, string>,
+  // 経歴の各項目は任意なので、保存値は string | undefined になる
+  values: Record<string, string | undefined>,
   enriched: Record<string, string> = {},
 ): BiographyRow[] =>
   BIOGRAPHY_FIELDS.map(({ key, inline, html }) => ({

--- a/module/applications/types.ts
+++ b/module/applications/types.ts
@@ -1,7 +1,9 @@
 import type { ApplicationRenderContext, ApplicationTab } from "@client/applications/_types.mjs";
 import type { HandlebarsRenderOptions } from "@client/applications/api/handlebars-application.mjs";
+import type { CharacteristicKey } from "../config/characteristics";
 import type { CharacterDataModel } from "../data/character";
 import type { EmokloreActor } from "../documents/actor";
+import type { ModifierSet } from "../rules/types";
 
 // Common type definitions
 export type EmotionKey = "surface" | "hidden" | "root";
@@ -16,13 +18,38 @@ export type EmokloreRenderOptions = HandlebarsRenderOptions & {
   [key: string]: unknown;
 };
 
+/** 技能1行の表示用データ。保存値と CONFIG.EMOKLORE 側の定義を合流させたもの */
 export type SkillRow = {
+  /**
+   * スキーマのフィールド。編集モードで formInput に渡す。
+   *
+   * `schema.getField()` は見つからなければ undefined を返す。スキーマは
+   * CONFIG.EMOKLORE と同じキー集合から作るので実際には引けるが、型のうえでは
+   * 落ちうるものとして扱う（テンプレート側は未定義なら描画しないだけで済む）。
+   */
+  field: foundry.data.fields.DataField | undefined;
+  /** 翻訳済みの表示名 */
+  label: string;
   level: number;
-  isExtra?: boolean;
+  target: number;
+  characteristic: CharacteristicKey;
+  specialization?: string;
+  mod: ModifierSet;
+  isExtra: boolean;
   /** 能力値の表示名。CONFIG.EMOKLORE から引いた翻訳済みの文字列 */
   characteristicLabel: string;
-  [key: string]: unknown;
+  /** 能力値のFont Awesomeアイコンクラス */
+  characteristicIcon: string;
 };
+
+/**
+ * label を持つスキーマフィールド。
+ *
+ * 本体の DataField は label を options から動的に載せており、クラスのプロパティ
+ * として宣言していない（common/data/fields.mjs の `_defaults`）。そのため型には
+ * 出てこないので、実際に使うメンバーだけを交差型で補う。
+ */
+export type LabeledField = foundry.data.fields.DataField & { label?: string };
 
 /** 経歴の項目の定義。並び順と見せ方だけを持ち、値は持たない */
 export type BiographyFieldDef = {
@@ -58,7 +85,13 @@ export type BaseSkillRow = {
 
 export type CharacteristicsMap = Record<
   string,
-  { field: foundry.data.fields.DataField; value: number }
+  {
+    /** スキーマのフィールド。引けない場合があるのは SkillRow#field と同じ */
+    field: foundry.data.fields.DataField | undefined;
+    value: number;
+    /** 能力値のFont Awesomeアイコンクラス */
+    icon: string;
+  }
 >;
 
 export type EmokloreActorSheetActions = {
@@ -119,6 +152,14 @@ export interface EmokloreDocumentSheetOptions {
   };
 }
 
+/**
+ * characterシートのコンテキスト。
+ *
+ * 基底（EmokloreDocumentSheetContext）は継承しない。継承すると基底の
+ * `[key: string]: unknown` まで引き継いでしまい、`context.charPintSum = 1` のような
+ * 打ち間違いが素通りするため。閉じた型のままでも `_prepareContext` のキャストは
+ * 素の as 1つで通る（アサーションの比較可能性は代入可能性より緩いため）。
+ */
 export type CharacterContext = {
   config: typeof CONFIG.EMOKLORE;
   system: CharacterDataModel;

--- a/module/data/character.ts
+++ b/module/data/character.ts
@@ -2,6 +2,15 @@ import type { BaseSkillKey } from "../config/base-skills";
 import type { CharacteristicKey } from "../config/characteristics";
 import type { SkillGroupKey } from "../config/skill-groups";
 import type { SkillKey } from "../config/skills";
+import {
+  calculateBaseSkillTarget,
+  calculateInitiative,
+  calculateMaxHp,
+  calculateMaxMp,
+  calculateSkillTarget,
+  clampToMax,
+  normalizeResonance,
+} from "../rules/derived-values";
 import type { SkillRollParams } from "../rules/skill-roll";
 import type { ModifierSet } from "../rules/types";
 import { EmokloreSystemDataModel } from "./system-model";
@@ -252,26 +261,35 @@ export class CharacterDataModel extends EmokloreSystemDataModel<CharacterDataMod
     super.prepareDerivedData();
 
     for (const skill of Object.values(this.skills)) {
-      skill.target = skill.level + this.characteristics[skill.characteristic].value;
+      skill.target = calculateSkillTarget(
+        skill.level,
+        this.characteristics[skill.characteristic].value,
+      );
     }
 
-    for (const skill of Object.values(this.baseSkills)) {
-      skill.target = this.characteristics[skill.characteristic].value;
+    // 〈手当〉の半減は calculateBaseSkillTarget が引き受ける。
+    // ここで後から目標値を上書きしないので、ループを触っても連動して壊れない
+    for (const [key, skill] of Object.entries(this.baseSkills)) {
+      skill.target = calculateBaseSkillTarget(
+        key,
+        this.characteristics[skill.characteristic].value,
+      );
     }
 
-    // 〈手当〉のみ能力値の半分（切り上げ）が目標値になる
-    this.baseSkills.treatment.target = Math.ceil(this.baseSkills.treatment.target / 2);
+    const { hp, mp, resonance } = this.resources;
+    hp.max = calculateMaxHp(this.characteristics.physical.value);
+    hp.value = clampToMax(hp.value, hp.max);
+    mp.max = calculateMaxMp(
+      this.characteristics.mentality.value,
+      this.characteristics.intelligence.value,
+    );
+    mp.value = clampToMax(mp.value, mp.max);
+    resonance.value = normalizeResonance(resonance.value);
 
-    this.resources.hp.max = 10 + this.characteristics.physical.value;
-    this.resources.hp.value = Math.min(this.resources.hp.value, this.resources.hp.max);
-
-    this.resources.mp.max =
-      this.characteristics.mentality.value + this.characteristics.intelligence.value;
-    this.resources.mp.value = Math.min(this.resources.mp.value, this.resources.mp.max);
-
-    this.resources.resonance.value = Math.max(this.resources.resonance.value, 1);
-
-    this.initiative = this.characteristics.physical.value + this.skills.speed.level;
+    this.initiative = calculateInitiative(
+      this.characteristics.physical.value,
+      this.skills.speed.level,
+    );
   }
 
   /**

--- a/module/rules/derived-values.test.ts
+++ b/module/rules/derived-values.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  calculateBaseSkillTarget,
+  calculateInitiative,
+  calculateMaxHp,
+  calculateMaxMp,
+  calculateSkillTarget,
+  clampToMax,
+  normalizeResonance,
+} from "./derived-values";
+
+describe("calculateSkillTarget", () => {
+  it("技能レベルと能力値を足す", () => {
+    expect(calculateSkillTarget(2, 4)).toBe(6);
+  });
+
+  it("未修得（レベル0）なら能力値がそのまま目標値になる", () => {
+    expect(calculateSkillTarget(0, 4)).toBe(4);
+  });
+});
+
+describe("calculateBaseSkillTarget", () => {
+  it("能力値がそのまま目標値になる", () => {
+    expect(calculateBaseSkillTarget("perception", 4)).toBe(4);
+  });
+
+  it("〈手当〉だけは能力値の半分になる", () => {
+    expect(calculateBaseSkillTarget("treatment", 4)).toBe(2);
+  });
+
+  it("〈手当〉の半分は切り上げる（能力値3なら2）", () => {
+    expect(calculateBaseSkillTarget("treatment", 3)).toBe(2);
+  });
+
+  it("〈手当〉は能力値1でも1を下回らない", () => {
+    expect(calculateBaseSkillTarget("treatment", 1)).toBe(1);
+  });
+});
+
+describe("calculateMaxHp", () => {
+  it("基礎値10に身体を足す", () => {
+    expect(calculateMaxHp(3)).toBe(13);
+  });
+});
+
+describe("calculateMaxMp", () => {
+  it("精神と知力を足す", () => {
+    expect(calculateMaxMp(3, 4)).toBe(7);
+  });
+});
+
+describe("normalizeResonance", () => {
+  it("0以下は1に丸める", () => {
+    expect(normalizeResonance(0)).toBe(1);
+    expect(normalizeResonance(-2)).toBe(1);
+  });
+
+  it("1以上はそのまま", () => {
+    expect(normalizeResonance(3)).toBe(3);
+  });
+});
+
+describe("calculateInitiative", () => {
+  it("身体に〈速度〉の技能レベルを足す", () => {
+    expect(calculateInitiative(4, 2)).toBe(6);
+  });
+});
+
+describe("clampToMax", () => {
+  it("現在値が最大値を超えていたら最大値に丸める", () => {
+    expect(clampToMax(15, 13)).toBe(13);
+  });
+
+  it("最大値以下ならそのまま", () => {
+    expect(clampToMax(8, 13)).toBe(8);
+  });
+});

--- a/module/rules/derived-values.ts
+++ b/module/rules/derived-values.ts
@@ -1,0 +1,67 @@
+/** HP最大値の基礎値。ここに身体を足したものが最大HPになる */
+export const HP_BASE = 10;
+
+/** 共鳴値の下限。判定でダイス数になるので0以下にはならない */
+export const RESONANCE_MIN = 1;
+
+/** 目標値が能力値の半分（切り上げ）になる基本技能。〈手当〉だけが該当する */
+const HALVED_TARGET_BASE_SKILL = "treatment";
+
+/** 〈手当〉の目標値を出すときに能力値を割る数 */
+const HALVED_TARGET_DIVISOR = 2;
+
+/**
+ * 技能の目標値。技能レベルに、紐づく能力値を足す。
+ */
+export function calculateSkillTarget(level: number, characteristicValue: number): number {
+  return level + characteristicValue;
+}
+
+/**
+ * 基本技能の目標値。
+ *
+ * 能力値がそのまま目標値になるが、〈手当〉だけは半分（切り上げ）になる。
+ * 半分にする判断をここに閉じ込めているので、呼び出し側は基本技能を一律に回すだけでよい。
+ */
+export function calculateBaseSkillTarget(key: string, characteristicValue: number): number {
+  return key === HALVED_TARGET_BASE_SKILL
+    ? Math.ceil(characteristicValue / HALVED_TARGET_DIVISOR)
+    : characteristicValue;
+}
+
+/**
+ * HP最大値。基礎値に身体を足す。
+ */
+export function calculateMaxHp(physical: number): number {
+  return HP_BASE + physical;
+}
+
+/**
+ * MP最大値。精神と知力の合計。
+ */
+export function calculateMaxMp(mentality: number, intelligence: number): number {
+  return mentality + intelligence;
+}
+
+/**
+ * 共鳴値を下限に丸める。
+ */
+export function normalizeResonance(value: number): number {
+  return Math.max(value, RESONANCE_MIN);
+}
+
+/**
+ * 行動値。身体に〈速度〉の技能レベルを足す。
+ */
+export function calculateInitiative(physical: number, speedLevel: number): number {
+  return physical + speedLevel;
+}
+
+/**
+ * 現在値が最大値を超えていたら最大値に丸める。
+ *
+ * 能力値が下がって最大値が縮んだときに、現在値だけが取り残されるのを防ぐ。
+ */
+export function clampToMax(value: number, max: number): number {
+  return Math.min(value, max);
+}


### PR DESCRIPTION
## 概要

Phase 2 の積み残し2件を片付ける。どちらも「以前のリファクタリングで潰したはずの問題が、別の形で残っていた」もの。

## 1. prepareDerivedData のルール計算を rules/ へ抽出

`module/data/character.ts` の `prepareDerivedData` が技能目標値・HP最大・MP最大・共鳴の下限・行動値というゲームルールそのものを抱えていた。`docs/architecture.md` の層分離表では `data/` は派生値計算を持ってよいが計算式の実装は置かない、と決めてあるので、算術を `module/rules/derived-values.ts` の純粋関数に出して `prepareDerivedData` は配線だけにした。

あわせて〈手当〉の順序依存を解消した。従来はループが `target` に能力値を書いたあとで `this.baseSkills.treatment.target` を半分にしており、ループ側を触ると連動して壊れる形だった。半減の判断を `calculateBaseSkillTarget` の中に閉じ込めたので、後から目標値を上書きする処理が無くなった。

マジックナンバー（10／下限1／除数2）には名前を付けた。「特定のキーだけ計算が違う」形は `character-points.ts` の `EXCLUDED_FROM_CHARACTERISTIC_POINTS` と同じなので、config ではなく rules に置いている。

`module/data/npc.ts` に派生値計算は無いので対象は character のみ。

## 2. as unknown as の解消

`as any` を55箇所すべて潰して `noExplicitAny` を error にしたが、同じ穴が `as unknown as` という別の名前で `character-sheet.ts` に5箇所残っていた。5箇所とも解消した。

`_getCharacteristics` / `_getSkills` の根本原因は戻り型ではなく、`foundry.utils.getProperty` への文字列パスという未型付きのアクセスだった。`system.skills` / `system.characteristics` は DataModel 側で型が付いているので、直接添字で引く形（`getSkillRollContext` と同じ）に変えてキャストを発生源から消した。

キャストは実際に型の取りこぼしを隠していた。`CharacteristicsMap` には `icon` が無いのに `_getCharacteristics` は `icon` を返し、`stat-row.hbs` がそれを描画していた。同じく `schema.getField()` は `undefined` を返しうるが、これも二重キャストで潰れていた。どちらも型に出した。

`SkillRow` の `[key: string]: unknown` はテンプレートが使う項目を全部書き出して外した。これで `_calculateSkillPointSumFromContext` の `Object.values` へのキャストも不要になった。

`_prepareContext` の二重キャストは、そもそも二重である必要が無かった。アサーションの比較可能性は代入可能性より緩く、基底が `document` / `system` を `unknown` へ広げているぶん素の `as` 1つで通る。`CharacterContext` を基底を継承する interface にする案も試したが、基底の `[key: string]: unknown` まで引き継いで `context.charPintSum = 1` のような打ち間違いが素通りするので採らなかった（実際に型チェックが通ってしまうことを確認済み）。

`module/settings.ts:28` と `module/utils/sheet.ts:72` は本体APIとの境界なので残している。

## 補足

Biomeには型アサーションを禁止するルールが無い。`as any` のときのように「解消して lint で固定する」ができないので、今回は解消するだけで再発は防げていない。

## 検証

`typecheck` / `lint` / `test` / `build` / `check:lang` / `check:templates` はすべて通る。テストは65件から78件に増えた。

静的チェックだけでは足りないので、develop と本ブランチの両方を実機（v14、ポート30014）で描画して突き合わせた。同じアクターの派生値（HP/MP最大・全技能の目標値・全基本技能の目標値・行動値）をJSONで出力して diff したところ完全一致。閲覧モード・編集モード・プロフィールタブのスクリーンショットも一致している。

〈手当〉は知力を奇数にした状態で確認した。知力3→目標値2、知力5→目標値3、いずれも切り上げ。同じ知力を参照する〈知識〉は半減されず3／5のままで、半減が〈手当〉だけに効いていることも確認した。テスト側でも切り上げを切り捨てに変えると落ちることを確認している。

現在値の丸めは HP/MP に99、共鳴に-5を入れて確認した。それぞれ14／6／1に丸まる。判定3種（技能・基本技能・共鳴）も実行し、`window.__errs` と `ui.notifications` は空。