### PR TITLE
as unknown as の再発防止（Biomeプラグイン）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      # プラグイン（tools/*.grit）を使うのでバージョンを固定する。
+      # package.json の @biomejs/biome と揃えること
       - uses: biomejs/setup-biome@v2
+        with:
+          version: 2.5.4
       - run: biome ci .
 
   build:

--- a/biome.json
+++ b/biome.json
@@ -14,7 +14,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "suspicious": {
         "noExplicitAny": "error"
       },

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "plugins": ["./tools/no-double-cast.grit"],
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -89,7 +89,8 @@ feat: add resonance roll dialog
 
 - TypeScript（strict化を段階的に進めている。現在 `strictNullChecks` / `noUncheckedIndexedAccess` / `noImplicitAny` が有効）。`any` は lint で禁止している（`noExplicitAny`）。本体JSDocの型が足りない場合は、`any` で潰さず**実際に使うメンバーだけを交差型で補う**（例: `module/utils/effects.ts`、`module/applications/types.ts` の `SheetDocument`）。どうしても必要なら理由コメント付きで `biome-ignore` する
 - UI文字列は `lang/ja.json` が正で、`en.json` はそれに追従する。スキーマの `label` などは `module/utils/localization.ts` の事前ローカライズ機構を通す
-- フォーマット・lintは [Biome](https://biomejs.dev/)（設定: `biome.json`）。手動実行は `npm run check`（修正適用）/ `npm run lint`（検証のみ）
+- **`as unknown as` の二重キャストは lint で禁止**している（`tools/no-double-cast.grit`）。まず素の `as` で通るか試すこと。アサーションの判定は代入可能性より緩いので、代入で弾かれても `as` 単体なら通ることが多い。本体APIとの境界などで本当に必要なときは、直前の行に `// biome-ignore lint: 理由` を付ける
+- フォーマット・lintは [Biome](https://biomejs.dev/)（設定: `biome.json`）。手動実行は `npm run check`（修正適用）/ `npm run lint`（検証のみ）。Biomeは型アサーションの組み込みルールを持たないため、上記の禁止はGritQLプラグインで実装している
 - 設計の方向性・既知の構造的課題は [アーキテクチャ](/architecture) を参照
 
 ### 自動チェック

--- a/emoklore.ts
+++ b/emoklore.ts
@@ -56,6 +56,7 @@ Hooks.once("init", () => {
   DocumentSheetConfig.registerSheet(
     Actor,
     "emoklore",
+    // biome-ignore lint: 本体のコンストラクタ型がジェネリクス開放のため素の as では通らない
     applications.EmokloreCharacterSheet as unknown as typeof foundry.applications.api.ApplicationV2,
     {
       types: ["character"],
@@ -67,6 +68,7 @@ Hooks.once("init", () => {
 Hooks.once("i18nInit", () => {
   // CONFIG.EMOKLORE のラベル（i18nキー）をその場で翻訳文字列に置き換える。
   // スキーマのラベルは LOCALIZATION_PREFIXES 経由で本体が処理するため、ここでは触らない
+  // biome-ignore lint: CONFIG.EMOKLORE は具体型なので汎用の Record へは素の as では通らない
   performPreLocalization(CONFIG.EMOKLORE as unknown as Record<string, unknown>);
 });
 

--- a/module/settings.ts
+++ b/module/settings.ts
@@ -25,6 +25,7 @@ type SettingRegistration = {
 type CoreSettingConfig = Parameters<typeof game.settings.register>[2];
 
 const register = (key: keyof EmokloreSettings, config: SettingRegistration): void => {
+  // biome-ignore lint: 本体の SettingConfig は登録後の形なので、登録時の形とは重ならない
   game.settings.register(systemID, key, config as unknown as CoreSettingConfig);
 };
 

--- a/module/utils/sheet.ts
+++ b/module/utils/sheet.ts
@@ -69,6 +69,7 @@ export const resolveEmbeddedDocumentClass = (
     throw new Error(`emoklore | 未対応の data-document-class: ${documentClass}`);
   }
   const cls = getDocumentClass(documentClass satisfies EmbeddedDocumentName);
+  // biome-ignore lint: ClientDocumentMixin のstaticが本体の型に出ないため素の as では通らない
   return cls as unknown as EmbeddedDocumentClass;
 };
 

--- a/tools/no-double-cast.grit
+++ b/tools/no-double-cast.grit
@@ -1,0 +1,14 @@
+// `x as unknown as T` を禁止する。
+//
+// Biomeには型アサーションを禁止する組み込みルールが無く、`noExplicitAny` を
+// error にしたときに `as any` の逃げ道として二重キャストが増えた経緯がある。
+// 二重が本当に必要なことは稀で、素の `as` で通ることが多い（アサーションの
+// 比較可能性は代入可能性より緩いため）。
+//
+// 本体APIとの境界などで本当に必要な場合は、直前の行に理由付きで
+// `// biome-ignore lint: 理由` を書く。
+language js
+
+`$expr as unknown as $type` where {
+  register_diagnostic(span=$expr, message="二重キャストは避ける。まず素の `as` で通るか試すこと。本体APIとの境界などで必要なら `// biome-ignore lint: 理由` を付ける", severity="error")
+}


### PR DESCRIPTION
PR #27 の積み残し。`as unknown as` を5箇所消したものの、Biomeに型アサーションを禁止する組み込みルールが無く再発を防げていなかった。`noExplicitAny` を error にしたときに `as any` の逃げ道として二重キャストが増えた経緯があるので、ここを塞がないと同じことが起きる。

**ベースは `refactor/derived-values-and-casts`（PR #27）。** #27 のマージ後に develop へ付け替える。

## やったこと

Biome 2.x のGritQLプラグインで書けることが分かったので `tools/no-double-cast.grit` として実装した。`$expr as unknown as $type` にマッチさせて error を出す。CIだけでなくエディタ上でも警告が出る。

本体APIとの境界で本当に必要な4箇所（`emoklore.ts` 2件・`module/settings.ts`・`module/utils/sheet.ts`）には理由付きで `biome-ignore` を付けた。いずれも元から説明コメントがある箇所。

`setup-biome` はバージョン未指定だと最新を取ってくるので、`package.json` の devDependency と揃えて 2.5.4 に固定した。

## 確認したこと

新しく二重キャストを書くと `biome ci` が終了コード1で落ちる（実際に1件仕込んで確認し、戻すと0に戻ることも確認した）。抑制済みの4箇所は静かなまま。

未知の設定キーがあると Biome は deserialize エラーで落ちるため、**プラグイン非対応のバージョンを引いた場合に黙って検査が素通りすることはない**。バージョン固定は挙動を決定的にするためで、安全弁としてはCIが赤くなる方が先に効く。

## 制約

プラグインの診断は `// biome-ignore lint: 理由` の形でしか抑制できない。`plugin:` や `plugin/no-double-cast:` を指定する形は `suppressions/parse` エラーになる。そのぶん行単位で他のlintルールも黙るので、付ける場所は最小限にとどめる必要がある。この点は `tools/no-double-cast.grit` のコメントとコミット本文に残した。

`typecheck` / `lint` / `test` / `build` / `check:lang` / `check:templates` / `docs:build` はすべて通る。