### PR TITLE
TypeScript を strict: true にし、残った緩い型を締める

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -87,7 +87,7 @@ feat: add resonance roll dialog
 
 ## コーディング方針
 
-- TypeScript（strict化を段階的に進めている。現在 `strictNullChecks` / `noUncheckedIndexedAccess` / `noImplicitAny` が有効）。`any` は lint で禁止している（`noExplicitAny`）。本体JSDocの型が足りない場合は、`any` で潰さず**実際に使うメンバーだけを交差型で補う**（例: `module/utils/effects.ts`、`module/applications/types.ts` の `SheetDocument`）。どうしても必要なら理由コメント付きで `biome-ignore` する
+- TypeScript は **`strict: true`**。加えて `noUncheckedIndexedAccess` / `noFallthroughCasesInSwitch` / `noImplicitOverride` / `noImplicitReturns` / `exactOptionalPropertyTypes` を有効にしている。任意プロパティに `undefined` を入れうる場合は `foo?: T | undefined` と書く。`any` は lint で禁止している（`noExplicitAny`）。本体JSDocの型が足りない場合は、`any` で潰さず**実際に使うメンバーだけを交差型で補う**（例: `module/utils/effects.ts`、`module/applications/types.ts` の `SheetDocument`）。どうしても必要なら理由コメント付きで `biome-ignore` する
 - UI文字列は `lang/ja.json` が正で、`en.json` はそれに追従する。スキーマの `label` などは `module/utils/localization.ts` の事前ローカライズ機構を通す
 - **`as unknown as` の二重キャストは lint で禁止**している（`tools/no-double-cast.grit`）。まず素の `as` で通るか試すこと。アサーションの判定は代入可能性より緩いので、代入で弾かれても `as` 単体なら通ることが多い。本体APIとの境界などで本当に必要なときは、直前の行に `// biome-ignore lint: 理由` を付ける
 - フォーマット・lintは [Biome](https://biomejs.dev/)（設定: `biome.json`）。手動実行は `npm run check`（修正適用）/ `npm run lint`（検証のみ）。Biomeは型アサーションの組み込みルールを持たないため、上記の禁止はGritQLプラグインで実装している

--- a/module/applications/actor-sheet.ts
+++ b/module/applications/actor-sheet.ts
@@ -27,6 +27,10 @@ export class EmokloreActorSheet extends EmokloreDocumentSheetMixin(
         return this.actor.rollSkill(dataset.skill!, { base: true });
       case "resonance":
         return this.actor.rollResonance();
+      default:
+        // 未知の data-roll-type は何もしない。テンプレート側の記述ミスなので、
+        // ここで握り潰していること自体は別途見直す余地がある
+        return undefined;
     }
   }
 }

--- a/module/applications/types.ts
+++ b/module/applications/types.ts
@@ -15,7 +15,6 @@ export type EmotionRow = { label: string; attribute: string };
 export type EmokloreRenderOptions = HandlebarsRenderOptions & {
   mode?: number;
   renderContext?: string;
-  [key: string]: unknown;
 };
 
 /** 技能1行の表示用データ。保存値と CONFIG.EMOKLORE 側の定義を合流させたもの */
@@ -33,7 +32,7 @@ export type SkillRow = {
   level: number;
   target: number;
   characteristic: CharacteristicKey;
-  specialization?: string;
+  specialization?: string | undefined;
   mod: ModifierSet;
   isExtra: boolean;
   /** 能力値の表示名。CONFIG.EMOKLORE から引いた翻訳済みの文字列 */
@@ -137,7 +136,6 @@ export interface EmokloreDocumentSheetContext extends ApplicationRenderContext {
   system: unknown;
   systemFields: Record<string, foundry.data.fields.DataField>;
   flags: Record<string, unknown>;
-  [key: string]: unknown;
 }
 
 // window / form はサブクラス側で省略できる（mixinのDEFAULT_OPTIONSがマージされるため）
@@ -155,10 +153,11 @@ export interface EmokloreDocumentSheetOptions {
 /**
  * characterシートのコンテキスト。
  *
- * 基底（EmokloreDocumentSheetContext）は継承しない。継承すると基底の
- * `[key: string]: unknown` まで引き継いでしまい、`context.charPintSum = 1` のような
- * 打ち間違いが素通りするため。閉じた型のままでも `_prepareContext` のキャストは
- * 素の as 1つで通る（アサーションの比較可能性は代入可能性より緩いため）。
+ * 基底（EmokloreDocumentSheetContext）は継承せず、必要なプロパティを並べ直している。
+ * 継承しても型は通るが、`context.charPintSum = 1` のような打ち間違いを捕まえるには
+ * 閉じた型のほうが確実で、シート側は全プロパティを明示して代入しているため困らない。
+ * `_prepareContext` のキャストは閉じた型のままでも素の as 1つで通る
+ * （アサーションの比較可能性は代入可能性より緩いため）。
  */
 export type CharacterContext = {
   config: typeof CONFIG.EMOKLORE;

--- a/module/data/character.ts
+++ b/module/data/character.ts
@@ -22,7 +22,7 @@ export type SkillRollContext = {
   params: SkillRollParams;
   label: string;
   isExtra: boolean;
-  specialization?: string;
+  specialization?: string | undefined;
 };
 
 const defineCharacterDataModelSchema = () => {

--- a/module/dice/emoklore-die.ts
+++ b/module/dice/emoklore-die.ts
@@ -35,6 +35,10 @@ export class EmokloreDie extends foundry.dice.terms.Die {
       result.success = outcome === "critical" || outcome === "success";
       result.failure = outcome === "fumble";
     }
+
+    // 本体のmodifierは false を返したときだけ失敗扱いになる。
+    // 成功時は undefined を返すのが規約なので、明示して返す
+    return undefined;
   }
 
   /**

--- a/module/rules/resonance-roll.ts
+++ b/module/rules/resonance-roll.ts
@@ -8,7 +8,7 @@ export type ResonanceRollParams = {
   resonanceValue: number;
   /** 判定の強度（目標値になる） */
   intensity: number;
-  emotionMatch?: ResonanceMatch;
+  emotionMatch?: ResonanceMatch | undefined;
 };
 
 /**

--- a/module/utils/sheet.ts
+++ b/module/utils/sheet.ts
@@ -53,7 +53,7 @@ type EmbeddedDocumentName = "Item" | "ActiveEffect";
  * `getDocumentClass` の戻り値の型には出てこない。
  */
 type EmbeddedDocumentClass = {
-  defaultName: (options: { type?: string; parent?: unknown }) => string;
+  defaultName: (options: { type?: string | undefined; parent?: unknown }) => string;
   create: (data: Record<string, unknown>, options?: Record<string, unknown>) => Promise<unknown>;
 };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,12 +8,12 @@
     "outDir": "dist",
     "noEmit": true,
 
-    "strict": false,
-    "strictNullChecks": true,
+    "strict": true,
     "noUncheckedIndexedAccess": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
-    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "exactOptionalPropertyTypes": true,
 
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
CI の警告と型チェックの緩いところを広く調べた結果のうち、型に関する分。

## strict: true はタダだった

`tsconfig.json` は `strict: false` のまま4つだけ個別に有効にする形だった。全フラグを個別に計測したところ **`strict: true` でもエラーは0件**で、コードはすでに完全に strict 準拠だった。単なる歴史的な残骸なので `strict: true` にする。

これで `strictFunctionTypes` / `strictBindCallApply` / `strictPropertyInitialization` / `noImplicitThis` / `useUnknownInCatchVariables` / `alwaysStrict` がまとめて有効になる。いずれも個別計測で0件を確認済み。

## 追加した2つ

**`noImplicitReturns`（2件）。** `actor-sheet` の `#onRoll` は `switch` に `default` が無く、未知の `data-roll-type` を黙って無視していた。挙動は変えずに `default` を明示し、握り潰していること自体はコメントで残した。`emoklore-die` の `emokloreSuccess` は本体のmodifier規約上 `undefined` 返しが正しいので、明示して返すようにした。

**`exactOptionalPropertyTypes`（4件）。** いずれも `foo?: T` に明示的な `undefined` を渡していた箇所。実際に `undefined` を取りうるので、宣言側を `?: T | undefined` に直して型を実態に合わせた。

## 索引シグネチャの削除

自前の型に残っていた `[key: string]: unknown` 2つ（`EmokloreRenderOptions` と `EmokloreDocumentSheetContext`）を外した。どちらも外してエラー0件。`CharacterContext` の打ち間違い検出（`charPintSum` → TS2551）が維持されることも確認済み。

## 入れなかったもの

`noPropertyAccessFromIndexSignature` は28件。ほぼ全部が `dataset.rollType` → `dataset['rollType']` で、DOM dataset に対して読みにくくなるだけなので見送った。

## 確認

新フラグが実際に機能することは、違反コードを4種類仕込んで `useUnknownInCatchVariables` / `exactOptionalPropertyTypes` / `strictPropertyInitialization` / `noImplicitReturns` がそれぞれ捕まえることを確認した。

挙動は変えていないが、ダイスのmodifierとロールの分岐を触っているので実機（v14、ポート30014）でも確認した。派生値は develop と同じ（HP最大14・MP最大6・行動値6・〈手当〉2・〈知識〉3）。判定3種が通り、`3d10em<=5` の出目が 10→count -1（ファンブル）、5→count +1（成功）×2 で合計1と、成功数の計算が正しく効いていることまで確認した。エラー・通知ともゼロ。

`typecheck` / `lint` / `test` / `build` / `check:lang` / `check:templates` / `docs:build` はすべて通る。