### PR TITLE
Biomeのルールを3つ追加し、見つかった箇所を直す

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -16,13 +16,16 @@
     "rules": {
       "preset": "recommended",
       "suspicious": {
-        "noExplicitAny": "error"
+        "noExplicitAny": "error",
+        "noShadow": "error"
       },
       "complexity": {
         "noThisInStatic": "off"
       },
       "style": {
-        "noNonNullAssertion": "off"
+        "noNonNullAssertion": "off",
+        "useDefaultSwitchClause": "error",
+        "useNumberNamespace": "error"
       }
     }
   },

--- a/module/applications/character-sheet.ts
+++ b/module/applications/character-sheet.ts
@@ -132,6 +132,9 @@ export class EmokloreCharacterSheet extends EmokloreActorSheet {
       case "effects":
         this._prepareEffectsContext(context);
         break;
+      default:
+        // header / tabs は追加のコンテキストを必要としないので何もしない
+        break;
     }
 
     if (partId in context.tabs) context.tab = context.tabs[partId] as unknown;

--- a/module/data/character.ts
+++ b/module/data/character.ts
@@ -43,7 +43,9 @@ const defineCharacterDataModelSchema = () => {
     }),
   });
 
-  const characteristic = {
+  // 能力値の NumberField に渡す共通オプション。技能側で分割代入する
+  // characteristic（能力値キーの文字列）とは別物なので名前を分けている
+  const characteristicFieldOptions = {
     min: 1,
     max: 6,
     initial: 1,
@@ -58,7 +60,7 @@ const defineCharacterDataModelSchema = () => {
         (obj as Record<string, foundry.data.fields.DataField>)[chc] = new SchemaField({
           // label は指定しない。定義時に設定すると localizeSchema の `this.label ||= ...` に
           // 勝ってしまい、ja.json の FIELDS 側の指定が効かなくなる
-          value: new NumberField({ ...characteristic }),
+          value: new NumberField({ ...characteristicFieldOptions }),
           mod: new SchemaField({
             bonus: new NumberField({ required: true, integer: true, initial: 0 }),
             success: new NumberField({ required: true, integer: true, initial: 0 }),

--- a/module/utils/charsheet-importer.ts
+++ b/module/utils/charsheet-importer.ts
@@ -275,8 +275,8 @@ export async function importFromCharSheet(
   for (const param of data.params) {
     const key = CHARACTERISTIC_MAP[param.label];
     if (key) {
-      characteristics[key] = parseInt(param.value, 10);
-      updateData[`system.characteristics.${key}.value`] = parseInt(param.value, 10);
+      characteristics[key] = Number.parseInt(param.value, 10);
+      updateData[`system.characteristics.${key}.value`] = Number.parseInt(param.value, 10);
     }
   }
 
@@ -284,8 +284,9 @@ export async function importFromCharSheet(
   if (data.status && Array.isArray(data.status)) {
     for (const status of data.status) {
       const label = status.label;
-      const value = typeof status.value === "string" ? parseInt(status.value, 10) : status.value;
-      const max = typeof status.max === "string" ? parseInt(status.max, 10) : status.max;
+      const value =
+        typeof status.value === "string" ? Number.parseInt(status.value, 10) : status.value;
+      const max = typeof status.max === "string" ? Number.parseInt(status.max, 10) : status.max;
 
       if (label === "HP") {
         updateData["system.resources.hp.value"] = value;


### PR DESCRIPTION
CI の警告と型チェックの緩いところを広く調べた結果のうち、lint に関する分。

**ベースは `refactor/strict-typescript`（PR #29）。** #29 のマージ後に develop へ付け替える。

## 選び方

推奨外のBiomeルールを全部かけて中身を確認したうえで、実害のある3つだけ足した。`preset: all` は700件超で、`useNamingConvention` 116件・`noMagicNumbers` 51件・`noConsole` 36件・`noTernary` 26件と大半がノイズなので採らない。

## 追加したルールと修正

**`noShadow`（2件）。** `module/data/character.ts` の外側にある `const characteristic` は能力値 `NumberField` の共通オプション（`{min:1, max:6, ...}`）で、技能スキーマの `reduce` 内で分割代入している `characteristic`（能力値キーの文字列）と同名だが全くの別物だった。読むときに取り違えるので `characteristicFieldOptions` に改名した。

**`useDefaultSwitchClause`（2件）。** `actor-sheet` 側は #29 で対応済みなので、残る `character-sheet` の `_preparePartContext` に `default` を足した。`header` と `tabs` は追加のコンテキストが要らないという意図をコメントで残している。

**`useNumberNamespace`（4件）。** `charsheet-importer` の `parseInt` を `Number.parseInt` に。Biomeの自動修正をそのまま採用した。

## 入れなかったもの

**`noUnnecessaryConditions`** は `actor-sheet` の `switch` の3分岐を「This case is unreachable」と報告するが、**実機で3経路とも実行してロールが飛ぶことを確認済み**なので誤検出。Biomeは型情報を持たないため `dataset.rollType` を正しく推論できない。5件中3件が誤りなので採らない。

**`useAwait`（7件）** は本体API契約上 `async` が必須のハンドラを咎めるので見送った。**`useImportExtensions`（90件）** はbundlerの解決方式と噛み合わない。

## 確認

スキーマ定義を触っているので実機（v14、ポート30014）で確認した。改名したオプションが `NumberField` に届いていることを、能力値フィールドの `min:1 / max:6 / initial:1` がスキーマから引けることで確かめている。派生値は develop と同じ（HP最大14・MP最大6・行動値6・〈手当〉2・〈知識〉3）、判定3種も通り、エラー・通知ともゼロ。

`charsheet-importer` はテストが5件あり、`parseInt` の置換後も通っている（全78件）。`typecheck` / `lint` / `test` / `build` / `check:lang` / `check:templates` はすべて通る。