### PR TITLE
boilerplate由来の英語コメントとデッドコードを掃除する

### DIFF
--- a/emoklore.ts
+++ b/emoklore.ts
@@ -17,11 +17,11 @@ Hooks.once("init", () => {
 
   registerSystemSettings();
 
-  // Configure custom Document implementations.
+  // Documentの実装クラスを差し替える
   CONFIG.Actor.documentClass = EmokloreActor;
   CONFIG.Item.documentClass = EmokloreItem;
 
-  // Configure System Data Models.
+  // system配下のデータモデルを登録する
   // TypeDataModel のコンストラクタ型はジェネリクスが開いたままなので、ModelData を
   // 固定したサブクラスは代入互換にならない。登録先の型として明示する
   CONFIG.Actor.dataModels = {
@@ -35,8 +35,7 @@ Hooks.once("init", () => {
   CONFIG.Dice.rolls.push(EmokloreRoll);
   CONFIG.Dice.terms.d = EmokloreDie;
 
-  // Configure trackable attributes.
-  // TODO: Not Translated
+  // トークンのリソースバーに出せる属性
   CONFIG.Actor.trackableAttributes = {
     character: {
       bar: ["resources.hp", "resources.mp", "resources.resonance"],
@@ -49,7 +48,6 @@ Hooks.once("init", () => {
   };
 
   const DocumentSheetConfig = foundry.applications.apps.DocumentSheetConfig;
-  // DocumentSheetConfig.unregisterSheet(Actor, "core", foundry.appv1.sheets.ActorSheet);
 
   // ApplicationV2 のコンストラクタ型はジェネリクスが開いたままなので、
   // 具体化したサブクラスは代入互換にならない。登録先が期待する型として明示する

--- a/module/applications/character-sheet.ts
+++ b/module/applications/character-sheet.ts
@@ -32,10 +32,11 @@ import type {
 } from "./types";
 
 /**
- * Extend the basic ActorSheet with some very simple modifications
- * @extends {ActorSheetV2}
+ * characterアクターのシート。
+ *
+ * 技能・プロフィール・効果の3タブを持ち、閲覧と編集をモードで出し分ける。
+ * モード切替とコンテキストの基礎部分は document-sheet-mixin が持つ。
  */
-
 export class EmokloreCharacterSheet extends EmokloreActorSheet {
   declare actor: EmokloreActor;
 
@@ -166,7 +167,6 @@ export class EmokloreCharacterSheet extends EmokloreActorSheet {
 
   static async _importCharacter(this: EmokloreCharacterSheet, event: Event, _target: HTMLElement) {
     event.preventDefault();
-    console.log("Opening import dialog for actor:", this.actor);
     await CharSheetImportDialog.show(this.actor);
   }
 

--- a/module/applications/charsheet-import-dialog.ts
+++ b/module/applications/charsheet-import-dialog.ts
@@ -11,7 +11,7 @@ type CharSheetImportDialogContext = ApplicationRenderContext & {
 };
 
 /**
- * Dialog for importing character data from character sheet website JSON
+ * キャラクター保管所のJSONを貼り付けて取り込むダイアログ
  */
 export class CharSheetImportDialog extends foundry.applications.api.HandlebarsApplicationMixin(
   foundry.applications.api.ApplicationV2,
@@ -74,7 +74,7 @@ export class CharSheetImportDialog extends foundry.applications.api.HandlebarsAp
       return;
     }
 
-    // Validate JSON
+    // 形が妥当かを先に見る
     const validation = validateCharSheetJSON(jsonInput);
 
     if (!validation.valid) {
@@ -86,23 +86,23 @@ export class CharSheetImportDialog extends foundry.applications.api.HandlebarsAp
       return;
     }
 
-    // Import the data
+    // 取り込む
     try {
       await importFromCharSheet(this.actor, validation.data!);
       this.close();
     } catch (error) {
-      console.error("Character import error:", error);
+      console.error("emoklore | キャラクターの取り込みに失敗しました", error);
       ui.notifications?.error(game.i18n.localize("EMOKLORE.Import.ErrorImportFailed"));
     }
   }
 
   static async onSubmit(_event: Event, _form: HTMLFormElement, _formData: unknown): Promise<void> {
-    // This is called when the form is submitted via the import button
-    // The actual import logic is handled by onImport
+    // tag が "form" なので本体がsubmitハンドラを要求するが、取り込み自体は
+    // onImport が済ませているのでここですることはない
   }
 
   /**
-   * Show the import dialog for an actor
+   * 指定したアクターに対してダイアログを開く
    */
   static async show(actor: EmokloreActor): Promise<CharSheetImportDialog> {
     const dialog = new CharSheetImportDialog(actor);

--- a/module/applications/document-sheet-mixin.ts
+++ b/module/applications/document-sheet-mixin.ts
@@ -64,7 +64,7 @@ export default (base: ApplicationV2Constructor) => {
       if (options.mode && this.isEditable) {
         this._mode = options.mode;
       }
-      // New sheets should always start in edit mode
+      // 新規作成のシートは編集モードで開く
       else if (options.renderContext === `create${this.document.documentName}`) {
         this._mode = EmokloreDocumentSheet.MODES.EDIT;
       }

--- a/module/applications/types.ts
+++ b/module/applications/types.ts
@@ -5,7 +5,6 @@ import type { CharacterDataModel } from "../data/character";
 import type { EmokloreActor } from "../documents/actor";
 import type { ModifierSet } from "../rules/types";
 
-// Common type definitions
 export type EmotionKey = "surface" | "hidden" | "root";
 
 /** 共鳴感情の表示用データ。どちらも翻訳済みの文字列で、未選択なら空文字 */
@@ -178,7 +177,7 @@ export type CharacterContext = {
   tabs: Record<string, ApplicationTab>;
   tab?: unknown;
   effects?: ReturnType<typeof import("../utils/effects").prepareActiveEffectCategories>;
-  // DocumentSheetContext properties
+  // 基底の EmokloreDocumentSheetContext と対応する分
   isPlay: boolean;
   owner: boolean;
   limited: boolean;

--- a/module/constants.ts
+++ b/module/constants.ts
@@ -1,6 +1,6 @@
 export const systemID = "emoklore" as const;
 
 /**
- * Translates repository paths to Foundry Data paths.
+ * リポジトリ内のパスを、Foundryが解決できる Data 配下のパスに変換する。
  */
 export const systemPath = (path: string): string => `systems/${systemID}/${path}`;

--- a/module/data/item-models.ts
+++ b/module/data/item-models.ts
@@ -2,10 +2,6 @@ import { EmokloreSystemDataModel } from "./system-model";
 
 const { NumberField, StringField } = foundry.data.fields;
 
-/* -------------------------------------------- */
-/*  Item Models                                 */
-/* -------------------------------------------- */
-
 const defineBaseItemDataModelSchema = () => {
   return {
     rarity: new StringField({

--- a/module/settings.ts
+++ b/module/settings.ts
@@ -53,10 +53,3 @@ export function registerSystemSettings(): void {
 export function getSetting<K extends keyof EmokloreSettings>(key: K): EmokloreSettings[K] {
   return game.settings.get(systemID, key) as EmokloreSettings[K];
 }
-
-export function setSetting<K extends keyof EmokloreSettings>(
-  key: K,
-  value: EmokloreSettings[K],
-): Promise<EmokloreSettings[K]> {
-  return game.settings.set(systemID, key, value) as Promise<EmokloreSettings[K]>;
-}

--- a/module/utils/charsheet-importer.ts
+++ b/module/utils/charsheet-importer.ts
@@ -1,7 +1,8 @@
 import type { EmokloreActor } from "../documents/actor";
 
 /**
- * Interface for the character sheet JSON format from emoklore.charasheet.jp
+ * キャラクター保管所（emoklore.charasheet.jp）が出力するJSONの形。
+ * CCFOLIA形式でコピーしたものを想定している
  */
 interface CharSheetJSON {
   kind: "character";
@@ -17,7 +18,7 @@ interface CharSheetJSON {
 }
 
 /**
- * Mapping from Japanese characteristic labels to system keys
+ * 能力値の日本語ラベル → システム内のキー
  */
 const CHARACTERISTIC_MAP: Record<string, string> = {
   身体: "physical",
@@ -31,7 +32,7 @@ const CHARACTERISTIC_MAP: Record<string, string> = {
 };
 
 /**
- * Mapping from Japanese skill labels (including markers) to system keys
+ * 技能の日本語ラベル（記号込み） → システム内のキー
  */
 const SKILL_MAP: Record<string, string> = {
   検索: "search",
@@ -72,7 +73,7 @@ const SKILL_MAP: Record<string, string> = {
 };
 
 /**
- * Mapping from Japanese base skill labels (with ＊ prefix) to system keys
+ * 基本技能の日本語ラベル（＊付き） → システム内のキー
  */
 const BASE_SKILL_MAP: Record<string, string> = {
   調査: "investigation",
@@ -91,7 +92,7 @@ const BASE_SKILL_MAP: Record<string, string> = {
 };
 
 /**
- * Mapping from Japanese emotion labels to system keys
+ * 共鳴感情の日本語ラベル → システム内のキー
  */
 const EMOTION_MAP: Record<string, string> = {
   // 欲望 (Desire)
@@ -192,7 +193,7 @@ export function parseEmotions(memo: string): ParsedEmotions {
 }
 
 /**
- * Parse skills from the commands field
+ * commands 欄のチャットパレットから技能を読み取る
  * Format: "2DM<=4 〈検索〉" or "1DM<=3 〈＊調査〉"
  */
 function parseSkills(commands: string): {
@@ -202,11 +203,11 @@ function parseSkills(commands: string): {
   const skills: Record<string, number> = {};
   const baseSkills: Record<string, number> = {};
 
-  // Split by newlines and process each command
+  // 1行1コマンドとして処理する
   const lines = commands.split("\n");
 
   for (const line of lines) {
-    // Match pattern: XDM<=Y 〈[＊★]SkillName〉
+    // 「XDM<=Y 〈［＊★］技能名〉」の形に一致させる
     const match = line.match(/(\d+)DM<=\d+\s*[〈<]([＊★]?)([^〉>]+)[〉>]/);
     if (!match?.[1] || !match[3]) continue;
 
@@ -214,19 +215,19 @@ function parseSkills(commands: string): {
     const marker = match[2];
     const skillName = match[3].trim();
 
-    // Base skills are marked with ＊
+    // 基本技能は＊が頭に付く
     if (marker === "＊") {
       const baseSkillKey = BASE_SKILL_MAP[skillName];
       if (baseSkillKey) {
-        baseSkills[baseSkillKey] = 1; // Base skills are always level 1
+        baseSkills[baseSkillKey] = 1; // 基本技能のレベルは常に1
       }
     } else {
-      // Regular skills - calculate level from dice count
+      // 通常技能はダイス数からレベルを求める
       const skillKey = SKILL_MAP[skillName];
       if (skillKey) {
-        // The skill level is typically dice count - 1, but we'll use a mapping based on the pattern
-        // This needs to account for characteristic value + skill level
-        // For now, store the dice count and we'll calculate later
+        // ここは未解決。ダイス数は「技能レベル＋能力値」の合計なので、本来は
+        // 能力値を引かないとレベルが出ない。今はダイス数をそのまま入れている。
+        // 正しい算出方法はルールブックで要確認（Issue #14）
         skills[skillKey] = diceCount;
       }
     }
@@ -236,8 +237,11 @@ function parseSkills(commands: string): {
 }
 
 /**
- * Calculate skill level from dice count and characteristic value
- * The dice count in the commands represents the skill level directly
+ * ダイス数から技能レベルを求める。
+ *
+ * 未完成。現状はダイス数をそのままレベルとして扱っており、能力値を考慮していない。
+ * 引数の能力値・技能キー・技能定義は、正しい算出に必要になる想定で受けているが
+ * まだ使っていない（Issue #14）。
  */
 function calculateSkillLevel(
   diceCount: number,
@@ -245,14 +249,12 @@ function calculateSkillLevel(
   _skillKey: string,
   _skillConfig: typeof CONFIG.EMOKLORE.skills,
 ): number {
-  // The dice count is the skill level itself
-  const skillLevel = diceCount;
-  // Clamp between 0 and 3
-  return Math.max(0, Math.min(3, skillLevel));
+  // 技能レベルの上限は3、下限は0
+  return Math.max(0, Math.min(3, diceCount));
 }
 
 /**
- * Import character data from the character sheet website JSON
+ * 保管所のJSONからアクターへ取り込む
  */
 export async function importFromCharSheet(
   actor: EmokloreActor,
@@ -265,12 +267,12 @@ export async function importFromCharSheet(
   const { data } = jsonData;
   const updateData: Record<string, unknown> = {};
 
-  // Import name
+  // 名前
   if (data.name) {
     updateData.name = data.name;
   }
 
-  // Import characteristics
+  // 能力値
   const characteristics: Record<string, number> = {};
   for (const param of data.params) {
     const key = CHARACTERISTIC_MAP[param.label];
@@ -280,7 +282,7 @@ export async function importFromCharSheet(
     }
   }
 
-  // Import resources (HP, MP, Resonance)
+  // リソース（HP / MP / 共鳴）
   if (data.status && Array.isArray(data.status)) {
     for (const status of data.status) {
       const label = status.label;
@@ -301,7 +303,7 @@ export async function importFromCharSheet(
     }
   }
 
-  // Import emotions from memo
+  // 共鳴感情はメモ欄から拾う
   const unrecognizedEmotions: string[] = [];
   if (data.memo) {
     const { emotions, unrecognized } = parseEmotions(data.memo);
@@ -310,20 +312,20 @@ export async function importFromCharSheet(
     }
     unrecognizedEmotions.push(...unrecognized);
 
-    // Store the full memo in biography notes
+    // メモ欄はそのまま経歴の備考に入れておく
     updateData["system.biography.note"] = data.memo;
   }
 
-  // Import skills from commands
+  // 技能はチャットパレットから拾う
   if (data.commands) {
     const { skills } = parseSkills(data.commands);
 
-    // For each skill found, calculate the level and set it
+    // 見つかった技能ごとにレベルを決めて入れる
     for (const [skillKey, diceCount] of Object.entries(skills)) {
       const skillInfo = CONFIG.EMOKLORE.skills[skillKey as keyof typeof CONFIG.EMOKLORE.skills];
       if (!skillInfo) continue;
 
-      // Get the characteristic this skill uses
+      // その技能が使う能力値を引く
       const charKey = skillInfo.characteristicOptions?.[0] || skillInfo.characteristic;
       if (!charKey) continue;
 
@@ -339,12 +341,12 @@ export async function importFromCharSheet(
     }
   }
 
-  // Store external URL as a flag for reference
+  // 元ページのURLはフラグに残しておく
   if (data.externalUrl) {
     updateData["flags.emoklore.externalUrl"] = data.externalUrl;
   }
 
-  // Apply all updates to the actor
+  // まとめてアクターへ反映する
   await actor.update(updateData);
 
   ui.notifications?.info(
@@ -364,7 +366,7 @@ export async function importFromCharSheet(
 }
 
 /**
- * Validate that the JSON string is valid character sheet data
+ * 貼り付けられた文字列が保管所のJSONとして妥当かを調べる
  */
 export function validateCharSheetJSON(jsonString: string): {
   valid: boolean;

--- a/module/utils/effects.ts
+++ b/module/utils/effects.ts
@@ -4,7 +4,6 @@ type SheetActiveEffect = ActiveEffect & { disabled: boolean; sort: number };
 export function prepareActiveEffectCategories(
   effects: Iterable<ActiveEffect>,
 ): Record<EffectCategory["type"], EffectCategory> {
-  // Define effect header categories
   const categories: Record<EffectCategory["type"], EffectCategory> = {
     temporary: {
       type: "temporary" as const,
@@ -23,14 +22,13 @@ export function prepareActiveEffectCategories(
     },
   };
 
-  // Iterate over active effects, classifying them into categories
+  // 無効なものを優先し、残りを一時的／恒常に振り分ける
   for (const e of effects as Iterable<SheetActiveEffect>) {
     if (e.disabled) categories.inactive.effects.push(e);
     else if (e.isTemporary) categories.temporary.effects.push(e);
     else categories.passive.effects.push(e);
   }
 
-  // Sort each category
   for (const c of Object.values(categories)) {
     c.effects.sort((a, b) => (a.sort || 0) - (b.sort || 0));
   }

--- a/module/utils/localization.ts
+++ b/module/utils/localization.ts
@@ -1,49 +1,41 @@
-/* -------------------------------------------- */
-/*  Config Pre-Localization                     */
-/* -------------------------------------------- */
-
-// Adapted from dnd5e and draw-steel
-
 /**
- * Storage for pre-localization configuration.
- * @type {object}
- * @private
+ * CONFIG の事前ローカライズ。dnd5e / draw-steel の仕組みを踏襲している。
+ *
+ * config には翻訳済みの文字列ではなくi18nキーを置いておき、`i18nInit` の時点で
+ * その場の値を翻訳結果に差し替える。こうするとスキーマ定義や config の読み込みが
+ * `game.i18n` の準備完了を待たずに済む。
  */
+
+/** どのキーを翻訳対象にするかの登録内容 */
 type PreLocalizationRegistration = {
   keys: string[];
 };
 
-const _preLocalizationRegistrations: Record<string, PreLocalizationRegistration> = {};
+const registrations: Record<string, PreLocalizationRegistration> = {};
 
-/* -------------------------------------------------- */
-
+/**
+ * `CONFIG.EMOKLORE` 配下のどのパスを翻訳するかを登録する。
+ *
+ * 値が文字列ならそのまま、オブジェクトなら `keys` で指定したプロパティを翻訳する。
+ */
 export function preLocalize(
   configKeyPath: string,
   { key, keys = [] }: { key?: string; keys?: string[] } = {},
 ) {
   if (key) keys.unshift(key);
-  _preLocalizationRegistrations[configKeyPath] = { keys };
+  registrations[configKeyPath] = { keys };
 }
 
-/* -------------------------------------------------- */
-
+/** 登録済みのパスをまとめて翻訳する。`i18nInit` から1回だけ呼ぶ */
 export function performPreLocalization(config: Record<string, unknown>) {
-  for (const [keyPath, settings] of Object.entries(_preLocalizationRegistrations)) {
+  for (const [keyPath, settings] of Object.entries(registrations)) {
     const target = foundry.utils.getProperty(config, keyPath);
     if (!target) continue;
-    _localizeObject(target as Record<string, unknown>, settings.keys);
+    localizeObject(target as Record<string, unknown>, settings.keys);
   }
-
-  // Localize & sort status effects
-  // CONFIG.statusEffects.forEach(s => s.name = game.i18n.localize(s.name));
-  // CONFIG.statusEffects.sort((lhs, rhs) =>
-  //   lhs.id === "dead" ? -1 : rhs.id === "dead" ? 1 : lhs.name.localeCompare(rhs.name, game.i18n.lang),
-  // );
 }
 
-/* -------------------------------------------------- */
-
-function _localizeObject(obj: Record<string, unknown>, keys?: string[]): void {
+function localizeObject(obj: Record<string, unknown>, keys?: string[]): void {
   for (const [k, v] of Object.entries(obj)) {
     const type = typeof v;
     if (type === "string") {
@@ -54,16 +46,14 @@ function _localizeObject(obj: Record<string, unknown>, keys?: string[]): void {
     if (type !== "object") {
       console.error(
         new Error(
-          `Pre-localized configuration values must be a string or object, ${type} found for "${k}" instead.`,
+          `emoklore | 事前ローカライズの対象は文字列かオブジェクトのみ。"${k}" は ${type} でした`,
         ),
       );
       continue;
     }
     if (!keys?.length) {
       console.error(
-        new Error(
-          "Localization keys must be provided for pre-localizing when target is an object.",
-        ),
+        new Error(`emoklore | 対象がオブジェクトのときは翻訳するキーの指定が要ります（"${k}"）`),
       );
       continue;
     }

--- a/module/utils/sheet.ts
+++ b/module/utils/sheet.ts
@@ -38,7 +38,7 @@ export const getEmbeddedDocument = (
       docRow.dataset.parentId === actor.id ? actor : actor.items.get(docRow.dataset.parentId!);
     return asSheetDocument(parent?.effects.get(docRow.dataset.effectId!));
   } else {
-    console.warn("Could not find document class");
+    console.warn(`emoklore | 未対応の data-document-class: ${docRow.dataset.documentClass}`);
     return null;
   }
 };
@@ -86,13 +86,11 @@ export const createDocumentData = (
     }),
   };
 
-  // Loop through the dataset and add it to our docData
+  // dataset の中身をそのまま作成データに載せる
   for (const [dataKey, value] of Object.entries(target.dataset)) {
-    // These data attributes are reserved for the action handling
+    // この2つはアクションの解決に使う予約語なので載せない
     if (["action", "documentClass"].includes(dataKey)) continue;
-    // Nested properties require dot notation in the HTML, e.g. anything with `system`
-    // An example exists in spells.hbs, with `data-system.spell-level`
-    // which turns into the dataKey 'system.spellLevel'
+    // 入れ子のプロパティはHTML側でドット記法で書く（`data-system.foo` → `system.foo`）
     foundry.utils.setProperty(docData, dataKey, value);
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,8 @@
     "noImplicitOverride": true,
     "noImplicitReturns": true,
     "exactOptionalPropertyTypes": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
 
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
コードベース全体の棚卸しで見つかったもののうち、コメントとデッドコードの分。

**ベースは `refactor/simplify-utils`（PR #34）。** #33 → #34 → 本PR の順に積んでいる。

## 英語コメント74行

`docs/contributing.md` はコメントを日本語と定めているが、boilerplate由来のファイルに英語が残っていた。意味のあるものは日本語化し、自明なものは削除。

特に紛らわしかったもの:

- **`utils/sheet.ts` が、このリポジトリに存在しない `spells.hbs` を例として挙げていた**（dnd5e系boilerplateの残骸）。実際の記法だけを説明する形に書き直した
- **`utils/localization.ts` にコメントアウトされた `statusEffects` の処理**が残っていた。ASCIIの罫線コメントとJS向けJSDoc（`@type` / `@private`）も併せて整理し、77→67行に
- `emoklore.ts` にコメントアウトされた `unregisterSheet` と `// TODO: Not Translated`
- `character-sheet.ts` の「Extend the basic ActorSheet with some very simple modifications」は内容も実態と合っていないので書き直した

`charsheet-importer.ts` は**未完成箇所の記述を失わないよう**、ダイス数から技能レベルを出す部分が未解決であることを日本語で明記し、Issue #14 を参照できるようにした。

## デッドコード

- **`character-sheet.ts` に本番のデバッグログ**（`console.log("Opening import dialog for actor:", ...)`）が残っていた
- `settings.ts` の `setSetting` が参照0件

## lintの穴を塞ぐ

`tsconfig.json` に `noUnusedLocals` / `noUnusedParameters` を追加した。

**biome の `noUnusedImports` は警告どまりで `biome ci` が終了コード0を返す**ため、未使用importが素通りしていた（実際に PR #33 の作業中に1件見逃している）。`biome check --write` も安全な修正ではないので自動削除しない。tsc なら型チェックで落とせて、**リポジトリ全体で既に0件**であることを確認済み。未使用のtype import・引数・ローカル変数の3種を仕込んで、それぞれ捕まることも確認した。

## 確認

実機で確認した。

- 事前ローカライズが効いたまま（`CONFIG.EMOKLORE` のラベルが `技巧` / `身体` / `手当て` と翻訳済み文字列になっている）。`localization.ts` を書き換えているのでここが要点
- 判定3種が通り、**余計なログが出ない**（Foundry本体のテンプレート読み込みログのみ）
- **インポートも保管所のサンプルJSONで一通り流した**。名前「テスト　テスト」・能力値（身体4 / 器用5）・共鳴感情（anger / dependence / friendship）・技能レベル（検索2 / 強運1）が正しく取り込まれる

エラー・通知はゼロ。`typecheck` / `lint` / `test`（78件）/ `build` / `check:lang` / `check:templates` はすべて通る。