### PR TITLE
立ち絵と能力値のカードをタブ共通の折りたためるサイドバーにする

### DIFF
--- a/css/applications/character-sheet.css
+++ b/css/applications/character-sheet.css
@@ -6,14 +6,39 @@
 }
 
 .emoklore.sheet.character {
-  /* Tab Layout */
-  section.tab {
-    overflow: auto;
-    padding: var(--spacer-12);
+  /* パートは .window-content 直下に兄弟として並ぶ。入れ子は作れないので、
+     サイドバーと内容を横に置くにはグリッドで配置するしかない。
+
+     本体は .window-content を flex 縦積み＋overflow: hidden にしている。
+     グリッドに変えても高さの決まり方（親のflexで flex: 1）は変わらない。
+
+     3行目を minmax(0, 1fr) にするのが要点。1fr だと最小が auto になり、
+     中身の高さがそのまま行を押し広げて独立スクロールが効かなくなる */
+  .window-content {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    grid-template-rows: auto auto minmax(0, 1fr);
   }
 
-  .tab.active {
-    column-gap: var(--spacer-12);
+  .em-sheet-header,
+  nav.tabs {
+    grid-column: 1 / -1;
+  }
+
+  .em-sidebar {
+    grid-column: 1;
+    grid-row: 3;
+  }
+
+  /* タブは中身だけを持つ。カードはサイドバーへ出したので2列組みは要らない。
+
+     サイドバーとの間隔はグリッドの column-gap ではなくサイドバー自身が持つ。
+     gap にすると、畳んで幅が0になっても隙間だけが残る */
+  section.tab {
+    grid-column: 2;
+    grid-row: 3;
+    overflow: auto;
+    padding: var(--spacer-12);
   }
 
   /* ヘッダ。名前とリソースを横に並べ、下端で揃える。
@@ -48,21 +73,7 @@
     }
   }
 
-  .tab.active {
-    display: grid;
-    grid-template-columns: var(--emoklore-sheet-sidebar-width) 1fr;
-  }
-
-  .effects.tab.active {
-    display: flex;
-  }
-
-  /* 左列のカード。中身なりの高さにする（既定の stretch だと列いっぱいに伸びる） */
-  .tab.active > .em-card {
-    align-self: start;
-  }
-
-  /* 右列。min-width: 0 がないと長い技能名が列を押し広げる */
+  /* min-width: 0 がないと長い技能名が列を押し広げる */
   .em-skills-column {
     min-width: 0;
   }

--- a/css/components/data-table.css
+++ b/css/components/data-table.css
@@ -6,7 +6,6 @@
     margin: 0;
     padding: 0;
     overflow-y: auto;
-    scrollbar-width: thin;
   }
 
   .em-data-table__body {

--- a/css/components/sidebar.css
+++ b/css/components/sidebar.css
@@ -1,20 +1,84 @@
 /* タブ共通のサイドバー。立ち絵と能力値のカードを載せる。
 
-   タブとの間隔もサイドバー自身が持つ。グリッド側に column-gap を置くと、
-   カードの有無にかかわらず隙間が固定されてしまう */
+   畳んだときに場所を1pxも残さないため、寸法も余白もすべてサイドバー自身が持つ。
+   グリッド側に column-gap を置くと、幅が0になっても隙間だけが残ってしまう。
+
+   切り抜きもしない。中身は translateX でシートの左外へ送り出し、
+   .window-content の overflow: hidden に任せる。こうするとトグルを
+   サイドバーの外に出しても切られない */
 
 .emoklore {
   .em-sidebar {
     position: relative;
     width: var(--emoklore-sheet-sidebar-width);
+    /* タブとの間隔もここが持つ。畳めば一緒に消える。
+       トグルがちょうど収まる幅（シート端の余白と同じ）にしてある */
     margin-inline-end: var(--spacer-16);
+    transition:
+      width 300ms ease,
+      margin-inline-end 300ms ease;
   }
 
-  /* 幅を固定しておく。親の都合でカードが潰れない。
+  /* 幅を固定しておく。親が縮んでもカードが潰れず、そのまま左へ滑る。
      scrollbar-width は本体が * に thin を当てているので指定しない */
   .em-sidebar__scroll {
     width: var(--emoklore-sheet-sidebar-width);
     height: 100%;
     overflow: hidden auto;
+    transition: transform 300ms ease;
+  }
+
+  /* カードの右肩からはみ出させる。サイドバーの幅の外にいるので、畳んで
+     幅が0になっても消えない（left: 100% がそのまま左端に来る）。
+
+     幅はシート端の余白（タブの区切り線と枠の間隔）と同じ。カード側に
+     めり込ませないよう、右だけ角を丸める。
+
+     色は本体のサイドバーの開閉ボタンに倣い、薄いグレーからホバーで
+     濃いグレーへ。地と枠はシートの面に合わせる */
+  .em-sidebar__toggle {
+    --control-bg-color: var(--emoklore-surface-sunken);
+    --control-border-color: var(--color-border);
+    --control-hover-bg-color: var(--emoklore-hover-surface);
+    --control-hover-border-color: var(--color-border);
+    --control-icon-color: var(--color-text-subtle);
+    --control-hover-icon-color: var(--color-text-emphatic);
+
+    position: absolute;
+    /* カードの角丸と重ならないよう、自分の高さの半分だけ下げる */
+    top: var(--spacer-16);
+    left: 100%;
+    width: var(--spacer-16);
+    height: 2rem;
+    /* 本体のボタンが持つ padding を残すと、border-box でも
+       padding + border より細くならず幅が合わない */
+    padding: 0;
+    border-radius: 0 4px 4px 0;
+    font-size: var(--font-size-12);
+    transition: transform 300ms ease;
+  }
+}
+
+/* 畳んだ状態。ルート要素に付くクラスで切り替える（character-sheet.ts の
+   _applySidebarState）。再描画を挟まないので、押した瞬間に反応する。
+
+   幅も余白も0にするので、タブ側はシートいっぱいに広がる。
+   トグルは絶対配置なので幅の外に居続ける */
+.emoklore.em-sidebar-collapsed {
+  .em-sidebar {
+    width: 0;
+    margin-inline-end: 0;
+  }
+
+  /* 自分の幅だけでは .window-content の内側の縁で止まり、シート端の余白の
+     ぶんが帯として残る。その余白も足して完全に外へ送り出す */
+  .em-sidebar__scroll {
+    transform: translateX(calc(-100% - var(--spacer-16)));
+  }
+
+  /* サイドバーに追従して余白の中まで下がる。ここまで来ると、
+     ボタンがちょうどシート端の余白を埋める */
+  .em-sidebar__toggle {
+    transform: translateX(calc(-1 * var(--spacer-16)));
   }
 }

--- a/css/components/sidebar.css
+++ b/css/components/sidebar.css
@@ -1,0 +1,20 @@
+/* タブ共通のサイドバー。立ち絵と能力値のカードを載せる。
+
+   タブとの間隔もサイドバー自身が持つ。グリッド側に column-gap を置くと、
+   カードの有無にかかわらず隙間が固定されてしまう */
+
+.emoklore {
+  .em-sidebar {
+    position: relative;
+    width: var(--emoklore-sheet-sidebar-width);
+    margin-inline-end: var(--spacer-16);
+  }
+
+  /* 幅を固定しておく。親の都合でカードが潰れない。
+     scrollbar-width は本体が * に thin を当てているので指定しない */
+  .em-sidebar__scroll {
+    width: var(--emoklore-sheet-sidebar-width);
+    height: 100%;
+    overflow: hidden auto;
+  }
+}

--- a/emoklore.css
+++ b/emoklore.css
@@ -10,6 +10,7 @@
 @import url("./css/components/meter.css");
 @import url("./css/components/utilities.css");
 @import url("./css/components/card.css");
+@import url("./css/components/sidebar.css");
 @import url("./css/components/emotion-list.css");
 @import url("./css/components/stat-row.css");
 @import url("./css/components/skill-row.css");

--- a/module/applications/character-sheet.ts
+++ b/module/applications/character-sheet.ts
@@ -14,6 +14,7 @@ import {
   calculateTotalSkillPoints,
   SKILL_POINT_MAX,
 } from "../rules/character-points";
+import { getSetting, setSetting } from "../settings";
 import { prepareActiveEffectCategories } from "../utils/effects";
 import {
   createDocumentData,
@@ -76,6 +77,7 @@ export class EmokloreCharacterSheet extends EmokloreActorSheet {
       toggleEffect: this._toggleEffect,
       importCharacter: this._importCharacter,
       selectSegment: this._selectSegment,
+      toggleSidebar: this._toggleSidebar,
     },
   };
 
@@ -96,6 +98,7 @@ export class EmokloreCharacterSheet extends EmokloreActorSheet {
         "templates/actor/partials/stat-row.hbs",
         "templates/actor/partials/segments.hbs",
       ].map(systemPath),
+      // トグルは畳んでも見えている必要があるので、内側だけをスクロールさせる
       scrollable: [".em-sidebar__scroll"],
     },
     skills: {
@@ -229,6 +232,54 @@ export class EmokloreCharacterSheet extends EmokloreActorSheet {
   }
 
   /**
+   * サイドバーの開閉。
+   *
+   * 再描画はしない。表示状態を切り替えるだけでドキュメントに触る理由がないうえ、
+   * submitOnChange の下でシート全体を描き直すとスクロール位置やフォーカスが動く。
+   * ルート要素のクラスだけを付け替える。
+   */
+  static async _toggleSidebar(this: EmokloreCharacterSheet): Promise<void> {
+    const collapsed = !getSetting("sidebarCollapsed");
+    await setSetting("sidebarCollapsed", collapsed);
+    this._applySidebarState(collapsed);
+  }
+
+  override async _onRender(
+    context: CharacterContext,
+    options: EmokloreRenderOptions,
+  ): Promise<void> {
+    await super._onRender(context, options);
+    this._applySidebarState(getSetting("sidebarCollapsed"));
+  }
+
+  private _applySidebarState(collapsed: boolean): void {
+    this.element.classList.toggle("em-sidebar-collapsed", collapsed);
+
+    // 畳んだ中身は枠の外へ送り出されて見えないだけなので、
+    // フォーカスと読み上げの対象からも外す
+    this.element.querySelector(".em-sidebar__scroll")?.toggleAttribute("inert", collapsed);
+
+    const toggle = this.element.querySelector(".em-sidebar__toggle");
+    if (!toggle) return;
+    toggle.setAttribute("aria-expanded", String(!collapsed));
+    toggle.setAttribute(
+      "data-tooltip",
+      collapsed ? "APPLICATION.ACTIONS.Expand" : "APPLICATION.ACTIONS.Collapse",
+    );
+
+    // 三角の向きはクラスを差し替えて変える。rotate だと、本体が button に
+    // 当てている transition: 0.5s（プロパティ無指定）に巻き込まれて
+    // 途中で三角が上を向く
+    toggle.classList.toggle("fa-caret-left", !collapsed);
+    toggle.classList.toggle("fa-caret-right", collapsed);
+
+    // 閲覧専用のシートでは本体の _toggleDisabled が .window-content 内の
+    // フォーム要素をまとめて無効化する（document-sheet.mjs の _onRender）。
+    // 開閉は編集ではないので、このボタンだけは押せる状態に戻す
+    if (toggle instanceof HTMLButtonElement) toggle.disabled = false;
+  }
+
+  /**
    * 能力値の表示用データ。
    *
    * アイコンは CONFIG.EMOKLORE 側の定義なので、テンプレートで二重の lookup を
@@ -314,6 +365,7 @@ export class EmokloreCharacterSheet extends EmokloreActorSheet {
     context.characteristics = this._getCharacteristics();
     context.charPointSum = calculateCharPointSum(context.characteristics);
     context.charPointMax = CHARACTERISTIC_POINT_MAX;
+    context.sidebarCollapsed = getSetting("sidebarCollapsed");
   }
 
   private _prepareSkillsContext(context: CharacterContext): void {

--- a/module/applications/character-sheet.ts
+++ b/module/applications/character-sheet.ts
@@ -87,13 +87,22 @@ export class EmokloreCharacterSheet extends EmokloreActorSheet {
     },
     // 本体のテンプレートなので systemPath は通さない
     tabs: { template: "templates/generic/tab-navigation.hbs" },
+    // タブに属さないパート。class="tab" と data-group を持たないので changeTab が
+    // 触らず、タブを切り替えてもDOMごと残る（スクロール位置も入力中の値も保たれる）
+    sidebar: {
+      template: systemPath("templates/actor/sidebar.hbs"),
+      templates: [
+        "templates/actor/partials/card.hbs",
+        "templates/actor/partials/stat-row.hbs",
+        "templates/actor/partials/segments.hbs",
+      ].map(systemPath),
+      scrollable: [".em-sidebar__scroll"],
+    },
     skills: {
       template: systemPath("templates/actor/skills-tab.hbs"),
       templates: [
         "templates/actor/skills.hbs",
         "templates/actor/base-skills.hbs",
-        "templates/actor/partials/card.hbs",
-        "templates/actor/partials/stat-row.hbs",
         "templates/actor/partials/skill-row-play.hbs",
         "templates/actor/partials/skill-row-edit.hbs",
         "templates/actor/partials/segments.hbs",
@@ -102,12 +111,7 @@ export class EmokloreCharacterSheet extends EmokloreActorSheet {
     },
     biography: {
       template: systemPath("templates/actor/biography.hbs"),
-      templates: [
-        "templates/actor/partials/card.hbs",
-        "templates/actor/partials/stat-row.hbs",
-        "templates/actor/partials/field.hbs",
-        "templates/actor/partials/segments.hbs",
-      ].map(systemPath),
+      templates: ["templates/actor/partials/field.hbs"].map(systemPath),
       scrollable: [""],
     },
     effects: {
@@ -148,6 +152,9 @@ export class EmokloreCharacterSheet extends EmokloreActorSheet {
     await super._preparePartContext(partId, context, options);
 
     switch (partId) {
+      case "sidebar":
+        this._prepareSidebarContext(context);
+        break;
       case "skills":
         this._prepareSkillsContext(context);
         break;
@@ -296,10 +303,20 @@ export class EmokloreCharacterSheet extends EmokloreActorSheet {
     );
   }
 
-  private _prepareSkillsContext(context: CharacterContext): void {
+  /**
+   * サイドバーの表示用データ。
+   *
+   * 能力値はカードにしか出ないので、ここでだけ用意する。以前は技能パートが
+   * 積んだものを経歴パートが拾っており（_preparePartContext は同じ context を
+   * 共有する）、パートの順序に暗黙に依存していた。
+   */
+  private _prepareSidebarContext(context: CharacterContext): void {
     context.characteristics = this._getCharacteristics();
     context.charPointSum = calculateCharPointSum(context.characteristics);
     context.charPointMax = CHARACTERISTIC_POINT_MAX;
+  }
+
+  private _prepareSkillsContext(context: CharacterContext): void {
     context.skills = this._getSkills();
     context.skillPointSum = this._calculateSkillPointSumFromContext(context.skills);
     context.skillPointMax = SKILL_POINT_MAX;

--- a/module/applications/types.ts
+++ b/module/applications/types.ts
@@ -189,6 +189,8 @@ export type CharacterContext = {
   characteristics?: CharacteristicsMap;
   charPointSum?: number;
   charPointMax?: number;
+  /** サイドバーを畳んでいるか。トグルの aria-expanded に使う */
+  sidebarCollapsed?: boolean;
   skills?: Record<string, SkillRow>;
   baseSkills?: BaseSkillRow[];
   skillPointSum?: number;

--- a/module/settings.ts
+++ b/module/settings.ts
@@ -3,6 +3,8 @@ import { systemID } from "./constants";
 interface EmokloreSettings {
   developerMode: boolean;
   developerActorId: string;
+  /** キャラクターシートのサイドバーを畳んでいるか。表示状態なのでユーザーごとに持つ */
+  sidebarCollapsed: boolean;
 }
 
 /**
@@ -13,7 +15,8 @@ interface EmokloreSettings {
  * そのため型変換はこのファイルの `register` に1箇所だけ閉じ込めている。
  */
 type SettingRegistration = {
-  name: string;
+  /** 設定画面に出す名前。`config: false` の内部状態には要らない */
+  name?: string;
   hint?: string;
   scope: "world" | "client" | "user";
   config: boolean;
@@ -48,8 +51,24 @@ export function registerSystemSettings(): void {
     type: String,
     default: "",
   });
+
+  // シートの表示状態なので設定画面には出さない。ユーザーごとに閉じるので client スコープ。
+  // アクターのフラグにするとGMが畳んだ状態がプレイヤーにも伝わってしまう
+  register("sidebarCollapsed", {
+    scope: "client",
+    config: false,
+    type: Boolean,
+    default: false,
+  });
 }
 
 export function getSetting<K extends keyof EmokloreSettings>(key: K): EmokloreSettings[K] {
   return game.settings.get(systemID, key) as EmokloreSettings[K];
+}
+
+export async function setSetting<K extends keyof EmokloreSettings>(
+  key: K,
+  value: EmokloreSettings[K],
+): Promise<void> {
+  await game.settings.set(systemID, key, value);
 }

--- a/templates/actor/biography.hbs
+++ b/templates/actor/biography.hbs
@@ -1,8 +1,7 @@
 {{! Biography Tab }}
 <section class="tab biography {{tab.cssClass}}" data-group="primary" data-tab="biography">
 
-  {{! 経歴タブでは編集モードでもカードは閲覧表示にする }}
-  {{> "systems/emoklore/templates/actor/partials/card.hbs" readonly=true}}
+  {{! 立ち絵と能力値はタブ共通のサイドバー（sidebar.hbs）が持つ }}
 
   {{! 項目の並びは module/applications/helpers.ts の BIOGRAPHY_FIELDS が持つ }}
   <div class="em-field-list">

--- a/templates/actor/partials/card.hbs
+++ b/templates/actor/partials/card.hbs
@@ -1,11 +1,12 @@
 {{!--
-  立ち絵と能力値のカード。技能タブと経歴タブの両方で使う。
+  立ち絵と能力値のカード。サイドバー（templates/actor/sidebar.hbs）から1回だけ呼ぶ。
 
-  @param readonly true なら編集モードでも閲覧表示にする（経歴タブ用）
+  以前は技能タブと経歴タブの2箇所から呼んでおり、経歴側だけ readonly=true で
+  閲覧表示に落としていた。入力が二重にならないようにするための回避策だったが、
+  サイドバーに1つだけ置く形にしたので不要になった。
 --}}
-{{! タブのグリッドの左列に直接載る。囲むだけのラッパは置かない }}
 <div class="em-card">
-  {{#if (or isPlay readonly)}}
+  {{#if isPlay}}
   <img
     class="em-card__image"
     src="{{source.img}}"
@@ -24,7 +25,7 @@
   {{/if}}
 
   <div class="em-stat-list">
-    {{#unless (or isPlay readonly)}}
+    {{#unless isPlay}}
     <div class="em-cap">{{charPointSum}} / {{charPointMax}}</div>
     {{/unless}}
 
@@ -32,7 +33,7 @@
     {{> "systems/emoklore/templates/actor/partials/stat-row.hbs"
       stat=chr
       key=key
-      view=(or @root.isPlay ../readonly)}}
+      view=@root.isPlay}}
     {{/each}}
   </div>
 </div>

--- a/templates/actor/sidebar.hbs
+++ b/templates/actor/sidebar.hbs
@@ -1,0 +1,14 @@
+{{!--
+  全タブ共通のサイドバー。立ち絵と能力値を載せる。
+
+  カードは必ずここ1箇所だけで描く。タブの中に置くと、非アクティブなタブも
+  DOMに残る（本体は display: none にするだけ）ため、同じ name の入力が
+  フォームに2組並ぶ。FormDataExtended は可視性を見ずに集め、同名を配列に
+  まとめてしまうので、能力値が "4,4" のような値で保存される。
+  以前カードを2箇所で描いていたときに整合性が取れなかったのはこれが原因。
+--}}
+<aside class="em-sidebar">
+  <div class="em-sidebar__scroll">
+    {{> "systems/emoklore/templates/actor/partials/card.hbs"}}
+  </div>
+</aside>

--- a/templates/actor/sidebar.hbs
+++ b/templates/actor/sidebar.hbs
@@ -6,9 +6,22 @@
   フォームに2組並ぶ。FormDataExtended は可視性を見ずに集め、同名を配列に
   まとめてしまうので、能力値が "4,4" のような値で保存される。
   以前カードを2箇所で描いていたときに整合性が取れなかったのはこれが原因。
+
+  @param sidebarCollapsed 畳んでいるか。トグルの aria-expanded に使う
 --}}
 <aside class="em-sidebar">
   <div class="em-sidebar__scroll">
     {{> "systems/emoklore/templates/actor/partials/card.hbs"}}
   </div>
+
+  {{! スクロール領域の外に置く。中に入れると一緒に流れて押せなくなる。
+      向き・ラベルは畳んだ状態で入れ替わる（以降は _applySidebarState が保つ） }}
+  <button
+    type="button"
+    class="ui-control plain icon fas em-sidebar__toggle
+      {{~#if sidebarCollapsed}} fa-caret-right{{else}} fa-caret-left{{/if}}"
+    data-action="toggleSidebar"
+    data-tooltip="{{#if sidebarCollapsed}}APPLICATION.ACTIONS.Expand{{else}}APPLICATION.ACTIONS.Collapse{{/if}}"
+    aria-expanded="{{#if sidebarCollapsed}}false{{else}}true{{/if}}"
+  ></button>
 </aside>

--- a/templates/actor/skills-tab.hbs
+++ b/templates/actor/skills-tab.hbs
@@ -1,6 +1,6 @@
 {{! Skills Tab }}
 <section class="tab skills {{tab.cssClass}}" data-group="primary" data-tab="skills">
-  {{> "systems/emoklore/templates/actor/partials/card.hbs"}}
+  {{! 立ち絵と能力値はタブ共通のサイドバー（sidebar.hbs）が持つ }}
   <div class="em-skills-column">
     {{> "systems/emoklore/templates/actor/skills.hbs"}}
     {{> "systems/emoklore/templates/actor/base-skills.hbs"}}


### PR DESCRIPTION
## 背景

立ち絵と能力値のカードは技能タブと経歴タブでそれぞれ描画されていた。タブごとにスクロールするので、編集中に下の技能を見ているとカードが画面外へ流れてしまう。効果タブにはそもそも出ない。

以前これを共通化しようとしたとき「編集時に複数タブ間ですべて編集できてしまい、整合性が取れなくなった」という失敗があり、その回避策として経歴タブのカードだけ閲覧専用にしていた（コミット `4912b0e`）。

## 失敗の原因が特定できた

本体の `foundry2.css:5781` は `.tab[data-tab]:not(.active) { display: none }` としているだけで、**非アクティブなタブはDOMに残る**。`FormDataExtended` の `#processFormFields` には可視性の判定が一切なく、隠れた入力もそのまま送信対象になる。そして同名の入力が2つあると `#getFieldValue` が配列にまとめ、`String(["4","4"])` で **`"4,4"` という値が警告なしに保存される**（NumberField なら `NaN` でバリデーション失敗）。

つまり原因はタブ側ではなく、**カードを2回描いていたこと**そのものだった。タブの外に1つだけ置けば原因ごと消える。

本体自身が同じ構造を持っているので独自のやり方は発明していない。`CategoryBrowser` / `JournalEntrySheet` / `ActiveEffectConfig` がいずれも「タブに属さないパート」を持つ。`changeTab` は `render()` を呼ばず `classList.toggle("active", ...)` するだけなので、`class="tab"` と `data-group` を持たないパートはタブ切替で一切触られない。スクロール位置も入力中の値も自然に保たれる。

## 変更内容

**カードを `sidebar` パートに移した。** これに伴い `card.hbs` の `readonly` を撤去し、能力値をどのタブからでも編集できるようにした。

**暗黙の依存も解消した。** これまで `_prepareBiographyContext` は `characteristics` を用意していないのに経歴タブのカードが描けていた。`_preparePartContext` が同じ context オブジェクトを共有しており、先に走る技能パートが残した値を拾っていたためで、パートの順序に依存していた。

**折りたたみを付けた。** 畳むと場所を1pxも残さず、タブがシートいっぱいに広がる。間隔をグリッドの `column-gap` ではなくサイドバー自身に持たせることで、幅が0になれば隙間も消える。

中身は `translateX` でシートの左外へ送り出し、`.window-content` が既に持っている `overflow: hidden` に切らせている。サイドバー自身が `overflow` を切らないので、トグルを幅の外に置いても消えない。

トグルはカードの右肩からはみ出す位置に置き、幅をシート端の余白（タブの区切り線と枠の間隔）と一致させた。畳むとサイドバーに追従して余白の中に収まる。見た目は本体のサイドバーの開閉ボタンに倣い、ラベルも `APPLICATION.ACTIONS.Collapse` / `Expand` を使う。

状態は client スコープの設定に持たせ、ユーザーごとに覚える。アクターのフラグにするとGMが畳んだ状態がプレイヤーにも伝わってしまう。切り替えは再描画せずルート要素のクラスを付け替えるだけにして、スクロール位置とフォーカスを動かさない。

## 実装中に踏んだ落とし穴

**本体は `button` に `transition: 0.5s` をプロパティ指定なしで当てている。** `rotate` で三角の向きを変えると0.5秒かけて回り、途中で90°＝上向きを通る。アイコンのクラスを差し替える形にした。

**閲覧専用のシートでは本体が `.window-content` 内のフォーム要素を一括で無効化する。** トグルもボタンなので巻き込まれ、オブザーバーが開閉できなくなる。開閉は編集ではないので、このボタンだけ有効に戻している。

**`box-sizing: border-box` でも `padding + border` より細くはならない。** 本体のボタンが持つ padding を外すまで、トグルの幅が18pxで止まっていた。

## 検証

v14実機で確認した。

- **同名入力が1組だけ**であること（カード1枚・入力6個。以前なら2枚・12個）
- **3タブそれぞれで能力値を編集し、正しく保存される**こと（`"2,2"` のような破壊なし、型も `number`）
- 技能タブを最下部までスクロールしてもカードが1pxも動かないこと
- タブを切り替えてもサイドバーのDOMノードが同一であること
- 畳むとタブが区切り線と完全に一致する幅（357–1083）まで広がり、カードがシート外へ完全に見切れること
- シートを閉じて開き直しても折りたたみ状態が残ること
- 閲覧／編集、ライト／ダーク、日本語／英語

`npm run lint` / `typecheck` / `check:templates` / `check:lang` / `test`（98件）はすべて通る。

## 既知の制約

最小幅601pxの編集モードでサイドバーを開いていると、技能行が横に収まらずスクロールが出る。これは変更前と同じ条件（技能列の幅は同一）で、**畳めば531pxになり解消する**。
