### PR TITLE
武器まわりの重複と余分な状態を畳む

### DIFF
--- a/css/chat/weapon-card.css
+++ b/css/chat/weapon-card.css
@@ -1,6 +1,14 @@
 /* 武器カードはシートの外に出るため、.emoklore スコープに入れない。
    自前のクラスはすべて em- 接頭辞なので、本体や他モジュールとは衝突しない */
 
+/* ダメージ適用の結果。対象1体につき1行の一覧なので ul で組み、
+   箇条書きの記号と既定の字下げだけ落とす */
+.em-damage-applied {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
 .em-weapon-card {
   display: flex;
   flex-direction: column;

--- a/module/applications/types.ts
+++ b/module/applications/types.ts
@@ -244,9 +244,7 @@ export type WeaponContext = {
   attackSkillLabel: string;
   /** 間合いの翻訳済み表示名。「近接」「遠隔」 */
   rangeTypeLabel: string;
-  /** 閲覧モードで出す射程。近接武器は間合いの表示名をそのまま出す */
-  rangeLabel: string;
-  /** 射程の行を閲覧で出すか。近接武器では間合いと同じ表示になるので出さない */
+  /** 射程の行を閲覧で出すか。近接武器と未記入の遠隔武器では間合いと重複するので出さない */
   showRange: boolean;
   /** 「【成功数】D3 ＋ 1D3」形式のダメージ式 */
   damagePreview: string;

--- a/module/applications/weapon-sheet.ts
+++ b/module/applications/weapon-sheet.ts
@@ -1,8 +1,7 @@
-import { attackSkills } from "../config/attack-skills";
 import { systemPath } from "../constants";
 import type { WeaponDataModel } from "../data/item-models";
 import type { EmokloreItem } from "../documents/item";
-import { formatDamagePreview, formatRangeLabel, localizeRangeType } from "../utils/weapon";
+import { formatDamagePreview, localizeAttackSkill, localizeRangeType } from "../utils/weapon";
 import EmokloreDocumentSheetMixin from "./document-sheet-mixin";
 import type { EmokloreRenderOptions, WeaponContext } from "./types";
 
@@ -42,11 +41,10 @@ export class EmokloreWeaponSheet extends EmokloreDocumentSheetMixin(
     const context = baseContext as WeaponContext;
     const system = this.item.system as WeaponDataModel;
 
-    // label は preLocalize の対象外（スキーマの choices と共有しているため）なので、ここで翻訳する
-    context.attackSkillLabel = game.i18n.localize(attackSkills[system.skill]?.label ?? "");
+    context.attackSkillLabel = localizeAttackSkill(system.skill);
     context.rangeTypeLabel = localizeRangeType(system.rangeType);
-    context.rangeLabel = formatRangeLabel(system.rangeType, system.range);
-    // 近接武器の射程は間合いと同じ表示になるので、閲覧では出さない（同じことを2度書かない）
+    // 近接武器の射程は間合いと同じ表示になるので、閲覧では出さない（同じことを2度書かない）。
+    // 出すときは必ず記入済みの遠隔武器なので、射程はそのまま見せればよい
     context.showRange = system.rangeType === "ranged" && Boolean(system.range);
     context.damagePreview = formatDamagePreview(system.damageDie, system.attackPower);
 

--- a/module/data/item-models.ts
+++ b/module/data/item-models.ts
@@ -9,22 +9,8 @@ import { EmokloreSystemDataModel } from "./system-model";
 
 const { HTMLField, StringField } = foundry.data.fields;
 
-// アイテム種別に共通するフィールドはまだない。武器と防具で共通のものが出てきたらここに置く
-const defineBaseItemDataModelSchema = () => {
-  return {};
-};
-
-export type BaseItemDataModelSchema = ReturnType<typeof defineBaseItemDataModelSchema>;
-
-export class BaseItemDataModel extends EmokloreSystemDataModel<BaseItemDataModelSchema> {
-  static override defineSchema() {
-    return defineBaseItemDataModelSchema();
-  }
-}
-
 const defineWeaponDataModelSchema = () => {
   return {
-    ...defineBaseItemDataModelSchema(),
     skill: new StringField({
       required: true,
       blank: false,
@@ -54,7 +40,7 @@ const defineWeaponDataModelSchema = () => {
 
 export type WeaponDataModelSchema = ReturnType<typeof defineWeaponDataModelSchema>;
 
-export class WeaponDataModel extends BaseItemDataModel {
+export class WeaponDataModel extends EmokloreSystemDataModel<WeaponDataModelSchema> {
   declare skill: AttackSkillKey;
   declare attackPower: string;
   declare range: string;

--- a/module/data/messages/weapon-card.ts
+++ b/module/data/messages/weapon-card.ts
@@ -1,10 +1,15 @@
 import { type AttackSkillKey, attackSkills } from "../../config/attack-skills";
 import type { EmokloreActor } from "../../documents/actor";
-import { buildDamageFormula, canRollDamage } from "../../rules/weapon-damage";
-import { createDamageAppliedMessage, type DamageApplied } from "../../utils/chat";
-import { requestApplyDamage } from "../../utils/queries";
+import { buildDamageFormula } from "../../rules/weapon-damage";
+import { createDamageAppliedMessage } from "../../utils/chat";
+import { applyDamageToTargets } from "../../utils/queries";
 import { resolveTargetActors } from "../../utils/targets";
-import { renderWeaponCard, type WeaponCardState } from "../../utils/weapon";
+import {
+  type CardButtons,
+  renderWeaponCard,
+  resolveCardButtons,
+  type WeaponCardState,
+} from "../../utils/weapon";
 import { EmokloreSystemDataModel } from "../system-model";
 
 const { DocumentUUIDField, NumberField, StringField } = foundry.data.fields;
@@ -85,13 +90,9 @@ export class WeaponCardModel extends EmokloreSystemDataModel<WeaponCardSchema> {
     return this.message.rolls[0];
   }
 
-  get damageRoll(): foundry.dice.Roll | undefined {
-    return this.message.rolls[1];
-  }
-
-  /** ダメージを振れるか。攻撃判定が済んでいて、かつ命中していること */
-  get canRollDamage(): boolean {
-    return this.successCount !== null && canRollDamage(this.successCount);
+  /** ボタンの出し分け。描画側と同じ判定を使う */
+  get buttons(): CardButtons {
+    return resolveCardButtons(this);
   }
 
   /**
@@ -100,7 +101,7 @@ export class WeaponCardModel extends EmokloreSystemDataModel<WeaponCardSchema> {
    * 攻撃判定は技能判定そのものなので、アクター側の組み立てをそのまま借りる。
    */
   async rollAttack(): Promise<void> {
-    if (this.successCount !== null) return;
+    if (!this.buttons.canRollAttack) return;
 
     const actor = await this.#resolveActor();
     if (!actor) {
@@ -119,7 +120,7 @@ export class WeaponCardModel extends EmokloreSystemDataModel<WeaponCardSchema> {
 
   /** ダメージを振り、同じカードに書き足す */
   async rollDamage(): Promise<void> {
-    if (!this.canRollDamage || this.damageTotal !== null) return;
+    if (!this.buttons.canRollDamage) return;
 
     const config = {
       // canRollDamage が成功数の非nullを保証している
@@ -149,7 +150,9 @@ export class WeaponCardModel extends EmokloreSystemDataModel<WeaponCardSchema> {
    * 1体でも触れないものが混じっていればGMのクライアントにまとめて肩代わりしてもらう。
    */
   async applyDamage(): Promise<void> {
-    if (this.damageTotal === null) return;
+    // canApplyDamage と同じ条件だが、ダメージ量の型を絞るためここでは直接見る
+    const amount = this.damageTotal;
+    if (amount === null) return;
 
     const targets = resolveTargetActors();
     if (targets.length === 0) {
@@ -157,31 +160,14 @@ export class WeaponCardModel extends EmokloreSystemDataModel<WeaponCardSchema> {
       return;
     }
 
-    // 1体でも触れないものが混じれば、触れるものも含めてまとめてGMに預ける。
-    // 一部だけ自分で処理すると適用の記録が2件に割れるため
-    const applied = targets.every((actor) => actor.isOwner)
-      ? await this.#applyLocally(targets)
-      : await requestApplyDamage(targets, this.damageTotal);
-
+    // 権限の有無とGMへの委譲は utils/queries.ts が引き受ける
+    const applied = await applyDamageToTargets(targets, amount);
     if (!applied) {
       ui.notifications?.warn("EMOKLORE.ChatMessage.weapon.NoGM", { localize: true });
       return;
     }
 
     if (applied.length > 0) await createDamageAppliedMessage(applied);
-  }
-
-  /** 自分の権限で適用する。委譲した場合と同じ形の結果を返す */
-  async #applyLocally(targets: EmokloreActor[]): Promise<DamageApplied[]> {
-    const applied: DamageApplied[] = [];
-
-    for (const actor of targets) {
-      const change = await actor.applyDamage(this.damageTotal as number);
-      // HPを持たないアクターやフックで中断された場合は結果が返らない
-      if (change) applied.push({ name: actor.name, ...change });
-    }
-
-    return applied;
   }
 
   /**

--- a/module/utils/queries.ts
+++ b/module/utils/queries.ts
@@ -23,7 +23,7 @@ type ApplyDamageQuery = {
 };
 
 /** 本体の型に出ないメンバーだけを補う */
-type QueryableUser = { isSelf: boolean; query: (name: string, data: unknown) => Promise<unknown> };
+type QueryableUser = { query: (name: string, data: unknown) => Promise<unknown> };
 
 /**
  * クエリの受け口を登録する。`init` で1回だけ呼ぶ。
@@ -42,39 +42,55 @@ export function registerQueries(): void {
 }
 
 /**
- * ダメージ適用をGMに肩代わりしてもらう。
+ * ダメージを対象に適用する。
  *
- * 自分がその指名GMなら委譲せずその場で処理する。
+ * 自分の権限で書けるならその場で、1体でも触れないものが混じっていればまとめてGMに
+ * 預ける。一部だけ自分で処理すると適用の記録が2件に割れるため。
  *
- * @returns 適用結果。GMが誰も接続していなければ undefined
+ * 呼ぶ側は権限もGMの有無も気にしなくてよい。
+ *
+ * @returns 適用結果。委譲が必要なのにGMが誰も接続していなければ undefined
  */
-export async function requestApplyDamage(
+export async function applyDamageToTargets(
   actors: EmokloreActor[],
   amount: number,
 ): Promise<DamageApplied[] | undefined> {
-  const gm = game.users?.activeGM as (QueryableUser & { id: string }) | null | undefined;
+  if (actors.every((actor) => actor.isOwner)) return applyDamage(actors, amount);
+
+  // ここに来た時点で自分はGMではない。GMは常に全アクターのOWNERなので、
+  // 上の every を抜けている（common/abstract/document.mjs の testUserPermission）
+  const gm = game.users?.activeGM as QueryableUser | null | undefined;
   if (!gm) return undefined;
 
   // 非リンクトークンの合成アクターは Scene.<id>.Token.<id>.Actor.<id> というUUIDを持ち、
   // これを送ることでそのトークンだけにダメージが入る。ワールドのアクターを送ると
   // 同じ元データから置いた雑魚が全員まとめて減る
-  const actorUuids = actors.map((actor) => actor.uuid).filter((uuid): uuid is string => !!uuid);
-
-  if (gm.isSelf) return applyDamageByUuid(actorUuids, amount);
-
-  const query: ApplyDamageQuery = { type: "applyDamage", actorUuids, amount };
+  const query: ApplyDamageQuery = {
+    type: "applyDamage",
+    actorUuids: actors.map((actor) => actor.uuid).filter((uuid): uuid is string => !!uuid),
+    amount,
+  };
 
   return (await gm.query(systemID, query)) as DamageApplied[];
 }
 
-/** UUIDで引いたアクターにダメージを適用する。委譲する側とされる側で同じ処理を通す */
+/** UUIDで引いたアクターに適用する。委譲を受けた側の入口 */
 async function applyDamageByUuid(actorUuids: string[], amount: number): Promise<DamageApplied[]> {
+  const resolved = await Promise.all(
+    actorUuids.map((uuid) => foundry.utils.fromUuid(uuid) as Promise<EmokloreActor | null>),
+  );
+
+  return applyDamage(
+    resolved.filter((actor): actor is EmokloreActor => !!actor),
+    amount,
+  );
+}
+
+/** 実際にHPを減らして結果を集める。委譲する側とされる側で同じ処理を通す */
+async function applyDamage(actors: EmokloreActor[], amount: number): Promise<DamageApplied[]> {
   const applied: DamageApplied[] = [];
 
-  for (const uuid of actorUuids) {
-    const actor = (await foundry.utils.fromUuid(uuid)) as EmokloreActor | null;
-    if (!actor) continue;
-
+  for (const actor of actors) {
     const change = await actor.applyDamage(amount);
     // HPを持たないアクターやフックで中断された場合は結果が返らない
     if (change) applied.push({ name: actor.name, ...change });

--- a/module/utils/weapon.ts
+++ b/module/utils/weapon.ts
@@ -21,6 +21,15 @@ export const localizeRangeType = (rangeType: RangeType): string =>
   game.i18n.localize(`EMOKLORE.Item.weapon.RangeType.${rangeType}`);
 
 /**
+ * 参照技能の表示名。
+ *
+ * attackSkills の label は preLocalize の対象外（スキーマの choices と共有しているため）
+ * なので、翻訳は引く側で行う。
+ */
+export const localizeAttackSkill = (skill: AttackSkillKey): string =>
+  game.i18n.localize(attackSkills[skill]?.label ?? "");
+
+/**
  * 武器の射程の表示。
  *
  * ルールブックに距離の規定がなく、近接武器は射程欄そのものを使わない。
@@ -54,6 +63,29 @@ export type WeaponCardState = {
   damageTotal: number | null;
 };
 
+/** カードのどのボタンが出るか。押せるかどうかの判定にも同じものを使う */
+export type CardButtons = {
+  canRollAttack: boolean;
+  canRollDamage: boolean;
+  canApplyDamage: boolean;
+};
+
+/**
+ * カードの進み具合からボタンの出し分けを決める。
+ *
+ * 描画とアクション側のガードで同じ条件が要る。別々に書くと、片方だけ直したときに
+ * 「押せるのに何も起きない」「押せないはずが実行される」という形でずれる。
+ */
+export const resolveCardButtons = (
+  state: Pick<WeaponCardState, "successCount" | "damageTotal">,
+): CardButtons => ({
+  canRollAttack: state.successCount === null,
+  canRollDamage:
+    state.successCount !== null && canRollDamage(state.successCount) && state.damageTotal === null,
+  // 適用は何度でも押せるようにしておく。狙いを変えて続けて当てることがある
+  canApplyDamage: state.damageTotal !== null,
+});
+
 /**
  * 武器カードのHTMLを組み立てる。
  *
@@ -68,15 +100,9 @@ export async function renderWeaponCard(
 
   return foundry.applications.handlebars.renderTemplate(CARD_TEMPLATE, {
     ...state,
-    skillLabel: game.i18n.localize(attackSkills[state.skill]?.label ?? ""),
+    ...resolveCardButtons(state),
+    skillLabel: localizeAttackSkill(state.skill),
     attackHTML: attackRoll ? await attackRoll.render() : "",
     damageHTML: damageRoll ? await damageRoll.render() : "",
-    canRollAttack: state.successCount === null,
-    canRollDamage:
-      state.successCount !== null &&
-      canRollDamage(state.successCount) &&
-      state.damageTotal === null,
-    // 適用は何度でも押せるようにしておく。狙いを変えて続けて当てることがある
-    canApplyDamage: state.damageTotal !== null,
   });
 }

--- a/templates/chat/damage-applied.hbs
+++ b/templates/chat/damage-applied.hbs
@@ -1,6 +1,6 @@
 {{! Damage Applied }}
-<div class="em-damage-applied">
+<ul class="em-damage-applied">
   {{#each lines as |line|}}
-    <div class="em-damage-applied__row">{{line}}</div>
+    <li>{{line}}</li>
   {{/each}}
-</div>
+</ul>

--- a/templates/item/weapon-detail.hbs
+++ b/templates/item/weapon-detail.hbs
@@ -19,7 +19,7 @@
       {{#if showRange}}
         <div class="em-field em-field--inline">
           <label class="em-field__label">{{systemFields.range.label}}</label>
-          <span class="em-field__value">{{rangeLabel}}</span>
+          <span class="em-field__value">{{system.range}}</span>
         </div>
       {{/if}}
       <div class="em-field">


### PR DESCRIPTION
#41 / #42 / #43 で入った武器まわり（約1,500行）を読み直して、重複と余分な状態を畳んだ。

**挙動は変えていない。** 実機で回帰を確認したうえで出している。

## 削ったもの

`BaseItemDataModel` はフィールドを1つも持たず、サブクラスも `WeaponDataModel` だけだった。防具で共通項が出るかもしれないという先回りで、実態のない足場がスキーマ関数・型・クラスの3つぶん積まれていた。共通のフィールドが実際に出てきたときに、その時点で必要な形で作ればよい。

`WeaponCardModel#damageRoll` はどこからも呼ばれていなかった。カードの描画側は `rolls` 配列を直接分解している。

## 重複

ボタンの出し分けを `resolveCardButtons` に集約した。描画側（`renderWeaponCard`）とアクション側のガード（`rollAttack` / `rollDamage` / `applyDamage`）が同じ条件を別の綴りで持っており、片方だけ直すと「押せるのに何も起きない」「押せないはずが実行される」という形でずれる状態だった。

ダメージ適用の委譲を `utils/queries.ts` へ寄せた。カードが「対象を全員所有しているか」「GMに投げるか」を判断していたが、それは委譲側の関心事で、カードは対象と量を渡すだけでよい。同じ適用ループがカードとクエリの両方にあったのも1つになり、`this.damageTotal as number` のキャストも消えた。

あわせて、委譲の分岐に入った時点で自分は必ず非GMであることが分かったので（GMは常に全アクターのOWNER — `common/abstract/document.mjs` の `testUserPermission` が `if (user.isGM) level = perms.OWNER`）、指名GMが自分かどうかを見る分岐を落とした。到達しない。

参照技能のローカライズを `localizeAttackSkill` に括った。カードとシートで同じ式を書いていた。

## 余分な状態

武器シートの `rangeLabel` を落とした。射程の行は記入済みの遠隔武器のときしか描かないので、間合いの表示名へ倒すフォールバックはシートでは絶対に発火しない。3つ持っていた値が2つで足りる。フォールバックが要るのはアイテムタブ側だけなので、`formatRangeLabel` はそのまま残している。

## マークアップ

ダメージ適用の結果を `ul` / `li` に組み直した。対象1体につき1行の一覧なので `div` を並べるのは意味的に合っていない。加えて振っていたクラスにCSS規則が1つも無く、`check:templates` はCSS側を見ないので気付けない状態だった。

## 実機で確認したこと

- ボタンの遷移が 攻撃判定 → ダメージ → 適用 と1つずつ進む
- 適用で 的 16 → 12 になり、チャットに `的 HP: 16 → 12` が出る
- 武器シートは近接（刀）で射程の行が出ず、遠隔（拳銃）で `射程 30m` が出る
- アイテムタブの4行がいずれも正しく並ぶ
- コンソールエラーは空

## 手を付けなかったもの

調査で挙げたが、判断が要るので残した。

- `WeaponCardState` がスキーマ・`declare` ブロック・型定義の3重管理。Foundryのスキーマから型を導けないので構造的に避けにくい
- `module/utils/weapon.ts` が表示整形とカード組み立ての2役。分けるとimportが増えるので好みの問題
- `EmokloreItem#use()` のインライン交差型
- `WeaponCardModel` が250行。Foundryの作法としては振る舞いをモデルに置くのが普通なので、分割しない方に傾いている
