### PR TITLE
命名規約を機械で守れるようにし、守れない分を明文化する

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -25,7 +25,21 @@
       "style": {
         "noNonNullAssertion": "off",
         "useDefaultSwitchClause": "error",
-        "useNumberNamespace": "error"
+        "useNumberNamespace": "error",
+        "useFilenamingConvention": "error",
+        "useNamingConvention": {
+          "level": "error",
+          "options": {
+            "strictCase": false,
+            "requireAscii": false,
+            "conventions": [
+              {
+                "selector": { "kind": "objectLiteralProperty" },
+                "formats": ["camelCase", "CONSTANT_CASE"]
+              }
+            ]
+          }
+        }
       }
     }
   },
@@ -37,6 +51,16 @@
     }
   },
   "overrides": [
+    {
+      "includes": ["tools/**"],
+      "linter": {
+        "rules": {
+          "style": {
+            "useNamingConvention": "off"
+          }
+        }
+      }
+    },
     {
       "includes": ["**/*.d.ts"],
       "linter": {

--- a/css/chat/dice-roll.css
+++ b/css/chat/dice-roll.css
@@ -12,7 +12,7 @@
 }
 
 /* 式の行に添える成功数修正。式本体より控えめにする */
-.dice-roll .dice-formula .success-mod {
+.dice-roll .dice-formula .em-success-mod {
   margin-left: 0.4rem;
   opacity: 0.7;
   font-size: var(--font-size-12);

--- a/docs/code-design.md
+++ b/docs/code-design.md
@@ -109,6 +109,18 @@ CSSの命名規約が [UI設計の規約](/ui-design) にあるのと同じく�
 | `*Ref` | 「どれを指すか」だけを持つ参照 | `SkillRef` |
 | `Emoklore*` | 本体のクラス・型を拡張したもの | `EmokloreActor` `EmokloreRoll` |
 
+## 名前の綴り
+
+**機械で守れるものはBiomeに書いてある**（`useNamingConvention` / `useFilenamingConvention`）。ここには、そのうえで人が判断する必要がある分だけ書く。
+
+- **頭字語は大文字のまま綴る**。`systemID` `noteHTML` `CharSheetJSON` `formatDMPart` のように、`Id` `Html` `Json` へ倒さない。本体APIが `enrichHTML` / `toJSON` / `innerHTML` と綴るので、そちらと地続きにしておくほうが読み替えが要らない。Biome側は `strictCase: false` で合わせてある
+- **モジュール定数はSCREAMING_SNAKE**（`SKILL_LEVEL_MAX` `HP_BASE` `CRITICAL_FACE`）。定数として並べるオブジェクトのキーも同じでよい（`{ PLAY: 1, EDIT: 2 }`）。`systemID` だけは頭字語の規則が優先する既存の例外
+- **ファイルとディレクトリはkebab-case**。例外なく守られている（実測で違反0件）ので、`useFilenamingConvention` で固定してある
+- **`Emoklore*` を付けるのは、本体クラスを継承して本体の同名概念を置き換えるものだけ**。`EmokloreActor` `EmokloreRoll` `EmokloreCharacterSheet` がそれで、本体に `Actor` `Roll` `ActorSheet` があるから区別が要る。`CharacterDataModel` や `CharSheetImportDialog` のように本体に同名の概念が無いものには付けない
+- **`rules/` の動詞は3つに絞る**。`calculate*` は数式（`calculateMaxHp`）、`resolve*` は入力から一意に決まる導出（`resolveSkillRoll`）、`build*` は複合物の組み立て（`buildDamageFormula`）
+
+`lang/*.json` のキーは名前空間をPascalCaseで切り、その下は camelCase にする（`EMOKLORE.Sheet.character.tab`）。**ドットを含むキーを1本の文字列で書かない** — 本体は読めるが、木として辿れなくなる。configのテーブルに対応する名前空間は、テーブル名と同じ複数形にする（`Actor.skillGroups`）。
+
 ## アサーション（`as`）の使いどころ
 
 **`as` は本体APIとの境界に寄せる。** 実測でキャストは58箇所あるが、**`config/` と `rules/` には1つも無い**。これは偶然ではなく、この2層がFoundryに依存しないから起きている。逆に、純粋なはずの層にキャストが現れたら、それは型付けの失敗ではなく層の設計が崩れている合図になる。

--- a/docs/code-design.md
+++ b/docs/code-design.md
@@ -113,8 +113,9 @@ CSSの命名規約が [UI設計の規約](/ui-design) にあるのと同じく�
 
 **機械で守れるものはBiomeに書いてある**（`useNamingConvention` / `useFilenamingConvention`）。ここには、そのうえで人が判断する必要がある分だけ書く。
 
-- **頭字語は大文字のまま綴る**。`systemID` `noteHTML` `CharSheetJSON` `formatDMPart` のように、`Id` `Html` `Json` へ倒さない。本体APIが `enrichHTML` / `toJSON` / `innerHTML` と綴るので、そちらと地続きにしておくほうが読み替えが要らない。Biome側は `strictCase: false` で合わせてある
-- **モジュール定数はSCREAMING_SNAKE**（`SKILL_LEVEL_MAX` `HP_BASE` `CRITICAL_FACE`）。定数として並べるオブジェクトのキーも同じでよい（`{ PLAY: 1, EDIT: 2 }`）。`systemID` だけは頭字語の規則が優先する既存の例外
+- **頭字語は大文字のまま綴る**。`noteHTML` `CharSheetJSON` `formatDMPart` のように `Html` `Json` へ倒さない。本体APIが `enrichHTML` / `toJSON` / `HTMLField` と綴るので、そちらと地続きにしておくほうが読み替えが要らない。Biome側は `strictCase: false` で合わせてある
+- **ただし `id` は例外で、`Id` と綴る**（`partId` `actorId` `itemId` `effectId`）。`partId` は本体ApplicationV2の綴りで、本体もこちら側。**頭字語だから大文字、と機械的に広げないこと**
+- **モジュール定数はSCREAMING_SNAKE**（`SYSTEM_ID` `SUCCESS_MODIFIER` `SKILL_LEVEL_MAX` `HP_BASE`）。定数として並べるオブジェクトのキーも同じでよい（`{ PLAY: 1, EDIT: 2 }`）。**Biomeは `const` に camelCase も CONSTANT_CASE も許すのでこれは機械で守れない。** 人が見るしかない
 - **ファイルとディレクトリはkebab-case**。例外なく守られている（実測で違反0件）ので、`useFilenamingConvention` で固定してある
 - **`Emoklore*` を付けるのは、本体クラスを継承して本体の同名概念を置き換えるものだけ**。`EmokloreActor` `EmokloreRoll` `EmokloreCharacterSheet` がそれで、本体に `Actor` `Roll` `ActorSheet` があるから区別が要る。`CharacterDataModel` や `CharSheetImportDialog` のように本体に同名の概念が無いものには付けない
 - **`rules/` の動詞は3つに絞る**。`calculate*` は数式（`calculateMaxHp`）、`resolve*` は入力から一意に決まる導出（`resolveSkillRoll`）、`build*` は複合物の組み立て（`buildDamageFormula`）

--- a/emoklore.ts
+++ b/emoklore.ts
@@ -66,7 +66,7 @@ Hooks.once("init", () => {
     {
       types: ["character"],
       makeDefault: true,
-      label: "EMOKLORE.SheetClass.character",
+      label: "EMOKLORE.Sheet.class.character",
     },
   );
 
@@ -78,7 +78,7 @@ Hooks.once("init", () => {
     {
       types: ["weapon"],
       makeDefault: true,
-      label: "EMOKLORE.SheetClass.weapon",
+      label: "EMOKLORE.Sheet.class.weapon",
     },
   );
 });

--- a/lang/en.json
+++ b/lang/en.json
@@ -24,19 +24,22 @@
     "Common": {
       "colon": ": "
     },
-    "SheetClass": {
-      "character": "Character Sheet",
-      "weapon": "Weapon Sheet"
-    },
-    "CharacterSheet": {
-      "tab": {
-        "biography": "Biography",
-        "skills": "Skills",
-        "items": "Items",
-        "effects": "Effects"
+    "Sheet": {
+      "class": {
+        "character": "Character Sheet",
+        "weapon": "Weapon Sheet"
       },
-      "fields": {
-        "specialization": "Specialization"
+      "toggleMode": "Toggle Play/Edit mode",
+      "character": {
+        "tab": {
+          "biography": "Biography",
+          "skills": "Skills",
+          "items": "Items",
+          "effects": "Effects"
+        },
+        "fields": {
+          "specialization": "Specialization"
+        }
       }
     },
     "Item": {
@@ -79,7 +82,6 @@
         "Applied": "{name} HP: {before} → {after}"
       }
     },
-    "SHEET.ToggleMode": "Toggle Play/Edit mode",
     "emotionAttributes": {
       "desire": "Desire",
       "passion": "Passion",
@@ -265,7 +267,7 @@
         "sociality": "Sociality",
         "fortune": "Fortune"
       },
-      "skillGroup": {
+      "skillGroups": {
         "investigation": "Investigation",
         "perception": "Perception",
         "negotiations": "Negotiations",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -8,7 +8,6 @@
       "weapon": "武器"
     }
   },
-
   "SETTINGS": {
     "EMOKLORE": {
       "DeveloperMode": {
@@ -21,24 +20,26 @@
       }
     }
   },
-
   "EMOKLORE": {
     "Common": {
       "colon": "："
     },
-    "SheetClass": {
-      "character": "キャラクターシート",
-      "weapon": "武器シート"
-    },
-    "CharacterSheet": {
-      "tab": {
-        "biography": "プロフィール",
-        "skills": "技能",
-        "items": "アイテム",
-        "effects": "効果"
+    "Sheet": {
+      "class": {
+        "character": "キャラクターシート",
+        "weapon": "武器シート"
       },
-      "fields": {
-        "specialization": "分野"
+      "toggleMode": "プレイ・編集モード切替",
+      "character": {
+        "tab": {
+          "biography": "プロフィール",
+          "skills": "技能",
+          "items": "アイテム",
+          "effects": "効果"
+        },
+        "fields": {
+          "specialization": "分野"
+        }
       }
     },
     "Item": {
@@ -81,8 +82,6 @@
         "Applied": "{name} HP: {before} → {after}"
       }
     },
-    "SHEET.ToggleMode": "プレイ・編集モード切替",
-
     "emotionAttributes": {
       "desire": "欲望",
       "passion": "情念",
@@ -90,7 +89,6 @@
       "relationship": "関係",
       "wound": "傷"
     },
-
     "resonantEmotions": {
       "selfAssertion": "自己顕示",
       "possession": "所有",
@@ -101,7 +99,6 @@
       "escape": "逃避",
       "curiosity": "好奇心",
       "thrill": "スリル",
-
       "joy": "喜び",
       "anger": "怒り",
       "sorrow": "哀しみ",
@@ -111,7 +108,6 @@
       "fear": "恐怖",
       "jealousy": "嫉妬",
       "grudge": "恨み",
-
       "justice": "正義",
       "worship": "崇拝",
       "goodAndEvil": "善悪",
@@ -122,7 +118,6 @@
       "order": "秩序",
       "admiration": "憧憬",
       "selflessness": "無我",
-
       "friendship": "友情",
       "love": "愛",
       "romance": "恋",
@@ -133,7 +128,6 @@
       "domination": "支配",
       "service": "奉仕",
       "indulgence": "甘え",
-
       "regret": "後悔",
       "loneliness": "孤独",
       "resignation": "諦観",
@@ -218,7 +212,6 @@
               }
             }
           },
-
           "biography": {
             "age": {
               "label": "年齢"
@@ -274,7 +267,7 @@
         "sociality": "社会",
         "fortune": "運勢"
       },
-      "skillGroup": {
+      "skillGroups": {
         "investigation": "調査系",
         "perception": "知覚系",
         "negotiations": "交渉系",

--- a/module/applications/character-sheet.ts
+++ b/module/applications/character-sheet.ts
@@ -131,7 +131,7 @@ export class EmokloreCharacterSheet extends EmokloreActorSheet {
   static override TABS = {
     primary: {
       tabs: [{ id: "skills" }, { id: "biography" }, { id: "items" }, { id: "effects" }],
-      labelPrefix: "EMOKLORE.CharacterSheet.tab",
+      labelPrefix: "EMOKLORE.Sheet.character.tab",
       initial: "skills",
     },
   };

--- a/module/applications/document-sheet-mixin.ts
+++ b/module/applications/document-sheet-mixin.ts
@@ -89,7 +89,7 @@ export default (base: ApplicationV2Constructor) => {
       toggleMode.type = "button";
       toggleMode.classList.add("header-control", "icon", "fa-solid", "fa-user-lock");
       toggleMode.dataset.action = "toggleMode";
-      toggleMode.dataset.tooltip = "EMOKLORE.SHEET.ToggleMode";
+      toggleMode.dataset.tooltip = "EMOKLORE.Sheet.toggleMode";
       this.window.controls.after(toggleMode);
 
       return frame;

--- a/module/applications/helpers.test.ts
+++ b/module/applications/helpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import type { EmotionAttributesConfig } from "../config/emotion-attributes";
-import type { ResonantEmotionsConfig } from "../config/resonant-emotions";
+import type { EmotionAttributeConfig } from "../config/emotion-attributes";
+import type { ResonantEmotionConfig } from "../config/resonant-emotions";
 import {
   BIOGRAPHY_FIELDS,
   BIOGRAPHY_PAIRED_COUNT,
@@ -10,12 +10,12 @@ import {
 } from "./helpers";
 
 // performPreLocalization 済みの CONFIG を模す。label は翻訳済みの文字列になっている
-const resonantEmotions: Record<string, ResonantEmotionsConfig> = {
+const resonantEmotions: Record<string, ResonantEmotionConfig> = {
   possession: { label: "独占", attribute: "desire" },
   hope: { label: "希望", attribute: "ideal" },
 };
 
-const emotionAttributes: Record<string, EmotionAttributesConfig> = {
+const emotionAttributes: Record<string, EmotionAttributeConfig> = {
   desire: { label: "欲望" },
   ideal: { label: "理想" },
 };

--- a/module/applications/helpers.ts
+++ b/module/applications/helpers.ts
@@ -1,5 +1,5 @@
-import type { EmotionAttributesConfig } from "../config/emotion-attributes";
-import type { ResonantEmotionsConfig } from "../config/resonant-emotions";
+import type { EmotionAttributeConfig } from "../config/emotion-attributes";
+import type { ResonantEmotionConfig } from "../config/resonant-emotions";
 import type { BiographyFieldDef, BiographyRow, EmotionKey, EmotionRow } from "./types";
 
 /**
@@ -84,8 +84,8 @@ export const createEmotionOptions = (): Array<{ value: string; label: string; gr
  */
 export const getEmotionRows = (
   emotions: Record<string, string | undefined>,
-  resonantEmotions: Record<string, ResonantEmotionsConfig>,
-  emotionAttributes: Record<string, EmotionAttributesConfig>,
+  resonantEmotions: Record<string, ResonantEmotionConfig>,
+  emotionAttributes: Record<string, EmotionAttributeConfig>,
 ): Record<EmotionKey, EmotionRow> => {
   const rows = {} as Record<EmotionKey, EmotionRow>;
 

--- a/module/applications/types.ts
+++ b/module/applications/types.ts
@@ -271,13 +271,3 @@ export type WeaponContext = {
   systemFields: Record<string, foundry.data.fields.DataField>;
   flags: Record<string, unknown>;
 };
-
-export type EmokloreCharacterSheetActions = {
-  viewDoc: (event: Event, target: HTMLElement) => Promise<void>;
-  createDoc: (event: Event, target: HTMLElement) => Promise<void>;
-  deleteDoc: (event: Event, target: HTMLElement) => Promise<void>;
-  toggleEffect: (event: Event, target: HTMLElement) => Promise<void>;
-  roll: (event: Event, target: HTMLElement) => Promise<unknown>;
-  // mixin側のDEFAULT_OPTIONSから継承チェーン経由でマージされるので、各シートでの宣言は任意
-  toggleMode?: (event: Event, target: HTMLElement) => Promise<void>;
-};

--- a/module/config/emotion-attributes.ts
+++ b/module/config/emotion-attributes.ts
@@ -1,4 +1,4 @@
-export interface EmotionAttributesConfig {
+export interface EmotionAttributeConfig {
   label: string;
 }
 
@@ -18,10 +18,10 @@ const definitions = {
   wound: {
     label: "EMOKLORE.emotionAttributes.wound",
   },
-} satisfies Record<string, EmotionAttributesConfig>;
+} satisfies Record<string, EmotionAttributeConfig>;
 
 export type EmotionAttributeKey = keyof typeof definitions;
 
-// satisfies だけだと各値が個別の狭い型に推論されるため、値の型は EmotionAttributesConfig に揃える。
+// satisfies だけだと各値が個別の狭い型に推論されるため、値の型は EmotionAttributeConfig に揃える。
 // キーは literal のまま保たれるので EmotionAttributeKey が使える
-export const emotionAttributes: Record<EmotionAttributeKey, EmotionAttributesConfig> = definitions;
+export const emotionAttributes: Record<EmotionAttributeKey, EmotionAttributeConfig> = definitions;

--- a/module/config/resonant-emotions.ts
+++ b/module/config/resonant-emotions.ts
@@ -1,6 +1,6 @@
 import type { EmotionAttributeKey } from "./emotion-attributes";
 
-export interface ResonantEmotionsConfig {
+export interface ResonantEmotionConfig {
   label: string;
   attribute: EmotionAttributeKey;
 }
@@ -198,10 +198,10 @@ const definitions = {
     label: "EMOKLORE.resonantEmotions.inferiorityComplex",
     attribute: "wound",
   },
-} satisfies Record<string, ResonantEmotionsConfig>;
+} satisfies Record<string, ResonantEmotionConfig>;
 
 export type ResonantEmotionKey = keyof typeof definitions;
 
-// satisfies だけだと各値が個別の狭い型に推論されるため、値の型は ResonantEmotionsConfig に揃える。
+// satisfies だけだと各値が個別の狭い型に推論されるため、値の型は ResonantEmotionConfig に揃える。
 // キーは literal のまま保たれるので ResonantEmotionKey が使える
-export const resonantEmotions: Record<ResonantEmotionKey, ResonantEmotionsConfig> = definitions;
+export const resonantEmotions: Record<ResonantEmotionKey, ResonantEmotionConfig> = definitions;

--- a/module/config/skill-groups.ts
+++ b/module/config/skill-groups.ts
@@ -1,33 +1,33 @@
-export interface SkillGroupsConfig {
+export interface SkillGroupConfig {
   label: string;
 }
 
 const definitions = {
   investigation: {
-    label: "EMOKLORE.Actor.skillGroup.investigation",
+    label: "EMOKLORE.Actor.skillGroups.investigation",
   },
   perception: {
-    label: "EMOKLORE.Actor.skillGroup.perception",
+    label: "EMOKLORE.Actor.skillGroups.perception",
   },
   negotiations: {
-    label: "EMOKLORE.Actor.skillGroup.negotiations",
+    label: "EMOKLORE.Actor.skillGroups.negotiations",
   },
   knowledge: {
-    label: "EMOKLORE.Actor.skillGroup.knowledge",
+    label: "EMOKLORE.Actor.skillGroups.knowledge",
   },
   athletic: {
-    label: "EMOKLORE.Actor.skillGroup.athletic",
+    label: "EMOKLORE.Actor.skillGroups.athletic",
   },
   survival: {
-    label: "EMOKLORE.Actor.skillGroup.survival",
+    label: "EMOKLORE.Actor.skillGroups.survival",
   },
   unique: {
-    label: "EMOKLORE.Actor.skillGroup.unique",
+    label: "EMOKLORE.Actor.skillGroups.unique",
   },
-} satisfies Record<string, SkillGroupsConfig>;
+} satisfies Record<string, SkillGroupConfig>;
 
 export type SkillGroupKey = keyof typeof definitions;
 
-// satisfies だけだと各値が個別の狭い型に推論されるため、値の型は SkillGroupsConfig に揃える。
+// satisfies だけだと各値が個別の狭い型に推論されるため、値の型は SkillGroupConfig に揃える。
 // キーは literal のまま保たれるので SkillGroupKey が使える
-export const skillGroups: Record<SkillGroupKey, SkillGroupsConfig> = definitions;
+export const skillGroups: Record<SkillGroupKey, SkillGroupConfig> = definitions;

--- a/module/constants.ts
+++ b/module/constants.ts
@@ -1,6 +1,6 @@
-export const systemID = "emoklore" as const;
+export const SYSTEM_ID = "emoklore" as const;
 
 /**
  * リポジトリ内のパスを、Foundryが解決できる Data 配下のパスに変換する。
  */
-export const systemPath = (path: string): string => `systems/${systemID}/${path}`;
+export const systemPath = (path: string): string => `systems/${SYSTEM_ID}/${path}`;

--- a/module/settings.ts
+++ b/module/settings.ts
@@ -1,4 +1,4 @@
-import { systemID } from "./constants";
+import { SYSTEM_ID } from "./constants";
 
 interface EmokloreSettings {
   developerMode: boolean;
@@ -29,7 +29,7 @@ type CoreSettingConfig = Parameters<typeof game.settings.register>[2];
 
 const register = (key: keyof EmokloreSettings, config: SettingRegistration): void => {
   // biome-ignore lint: 本体の SettingConfig は登録後の形なので、登録時の形とは重ならない
-  game.settings.register(systemID, key, config as unknown as CoreSettingConfig);
+  game.settings.register(SYSTEM_ID, key, config as unknown as CoreSettingConfig);
 };
 
 export function registerSystemSettings(): void {
@@ -63,12 +63,12 @@ export function registerSystemSettings(): void {
 }
 
 export function getSetting<K extends keyof EmokloreSettings>(key: K): EmokloreSettings[K] {
-  return game.settings.get(systemID, key) as EmokloreSettings[K];
+  return game.settings.get(SYSTEM_ID, key) as EmokloreSettings[K];
 }
 
 export async function setSetting<K extends keyof EmokloreSettings>(
   key: K,
   value: EmokloreSettings[K],
 ): Promise<void> {
-  await game.settings.set(systemID, key, value);
+  await game.settings.set(SYSTEM_ID, key, value);
 }

--- a/module/utils/queries.ts
+++ b/module/utils/queries.ts
@@ -12,7 +12,7 @@
  * draw-steel の `DrawSteelSocketHandler` と同じ形。
  */
 
-import { systemID } from "../constants";
+import { SYSTEM_ID } from "../constants";
 import type { EmokloreActor } from "../documents/actor";
 import type { DamageApplied } from "./chat";
 
@@ -33,7 +33,7 @@ type QueryableUser = { query: (name: string, data: unknown) => Promise<unknown> 
 export function registerQueries(): void {
   const queries = CONFIG.queries as Record<string, (data: unknown) => Promise<unknown>>;
 
-  queries[systemID] = async (data) => {
+  queries[SYSTEM_ID] = async (data) => {
     const query = data as Partial<ApplyDamageQuery> | null;
     if (query?.type !== "applyDamage") return null;
 
@@ -71,7 +71,7 @@ export async function applyDamageToTargets(
     amount,
   };
 
-  return (await gm.query(systemID, query)) as DamageApplied[];
+  return (await gm.query(SYSTEM_ID, query)) as DamageApplied[];
 }
 
 /** UUIDで引いたアクターに適用する。委譲を受けた側の入口 */

--- a/templates/actor/partials/skill-row-edit.hbs
+++ b/templates/actor/partials/skill-row-edit.hbs
@@ -12,7 +12,7 @@
     {{#if skill.field.fields.specialization}}
     {{formInput skill.field.fields.specialization
       value=skill.specialization
-      placeholder=(localize "EMOKLORE.CharacterSheet.fields.specialization")}}
+      placeholder=(localize "EMOKLORE.Sheet.character.fields.specialization")}}
     {{/if}}
   </span>
 

--- a/templates/rolls/skill.hbs
+++ b/templates/rolls/skill.hbs
@@ -5,7 +5,7 @@
   <div class="dice-result">
     <div class="dice-formula">
       {{dmFormula}}
-      {{#if successModLabel}}<span class="success-mod">{{successModLabel}}</span>{{/if}}
+      {{#if successModLabel}}<span class="em-success-mod">{{successModLabel}}</span>{{/if}}
     </div>
     {{{tooltip}}}
     <h4 class="dice-total">{{resultLabel}}</h4>


### PR DESCRIPTION
#48 に積む（baseは `chore/config-gaps`）。命名の一貫性を全数調べ、Biomeで守れるものは設定に、守れないものはドキュメントに落とした。

**命名は9割方すでに一貫していた。** 問題は「一貫しているが、どこにも書かれていないので機械が守れない」ことのほうだった。

## Biomeに書く

`useNamingConvention` を実測したら違反は**14件だけ**だった（記録に残っていた116件は `preset: all` を丸ごと試したときの古い値）。しかも内訳を見ると、いずれも規約違反ではなく**Biomeの既定と綴りの流儀が違うだけ**だった。

| 内訳 | 件数 | 対応 |
|---|---|---|
| 頭字語（`systemID` `noteHTML` `CharSheetJSON` `formatDMPart`） | 8 | `strictCase: false` |
| 定数オブジェクトのキー（`{ PLAY: 1, EDIT: 2 }`） | 2 | `objectLiteralProperty` に CONSTANT_CASE を許す |
| テストの日本語キー（`{ 検索: "search" }`） | 1 | `requireAscii: false` |
| `tools/` のHTTPヘッダ（`Referer` `Cookie` `User-Agent`） | 3 | `tools/**` を対象外に |

頭字語を `Id` / `Html` / `Json` へ倒す道もあるが、本体APIが `enrichHTML` / `toJSON` / `innerHTML` と綴るので、そちらと地続きにしておくほうが読み替えが要らない。**既定に倒すのではなく、こちらの流儀をオプションとして書いた。**

`useFilenamingConvention` は**違反0件**だったのでそのまま入れた。kebab-caseは例外なく守られていたが、規約として書かれていなかった。

両ルールとも、意図的に違反を入れて赤くなることを確認してある。

## 実際に食い違っていたもの

- **`SkillGroupsConfig` / `EmotionAttributesConfig` / `ResonantEmotionsConfig`** が複数形。同じファイルの1〜2行違いにある `*Key` 型はすべて単数で、**自分自身と食い違っていた**。単数に揃えた
- **`.success-mod`** が `em-` 接頭辞を持たない唯一の自前クラス。しかも意図的に `.emoklore` の外（チャットログ）に置かれているので、本当にグローバルな名前空間を占めていた
- **`SHEET.ToggleMode`** がドットを含むキーを1本の文字列で書いていた。本体はフラット化して読むので動くが、木として辿れない。あわせて `SheetClass` / `CharacterSheet` / `SHEET` と3系統に散っていた「シート」の名前空間を `Sheet` の下に寄せた（参照は5箇所だけだった）
- **`Actor.skillGroup`** だけが単数。configのテーブルに対応する名前空間で他は全部複数形
- **`EmokloreCharacterSheetActions`** が定義だけで参照が無かった

## ドキュメントに書く

Biomeで守れる分は設定が正なので、`docs/code-design.md` には**人が判断する必要がある分**だけ書いた。頭字語の扱い、モジュール定数の綴り、`Emoklore*` を付ける範囲、`rules/` で使う動詞、langキーの名前空間の切り方。

`Emoklore*` の範囲はこれまで「本体のクラス・型を拡張したもの」とあり、字義通りに読むと `CharacterDataModel` にも付けることになっていた。実態は「本体に同名の概念があって区別が要るもの」だけなので、そう書き直した（＝改名は不要）。

## 今回見送ったもの

`ModifierSet.target` と `RollSpec.target` の同名異義（テンプレートで `skill.target` と `skill.mod.target` が隣り合う）、`rangeLabel` が2つの意味を持つ件、`chc`/`chr` のループ変数、PARTS idとテンプレート名の不一致。いずれも実害があるが型と描画に触るので、命名PRに混ぜると差分が読めなくなる。

## 検証

`npm run verify:live` 23件すべて通過。**langキーの改名は描画に出る**ので実機で確認した（「未解決の翻訳キーが表示されていない」が効く）。lint / typecheck / test 115件 / check:lang（218件一致）/ check:templates も通る。