### PR TITLE
スキーマを明文化し、ドキュメントの綴りを機械で守る

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
         run: npm run check:lang
       - name: Check Handlebars templates
         run: npm run check:templates
+      - name: Check schema doc
+        run: npm run check:schema-doc
       - name: Build docs
         run: npm run docs:build
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -29,6 +29,7 @@ export default defineConfig({
           { text: "ロードマップ", link: "/roadmap" },
           { text: "アーキテクチャ", link: "/architecture" },
           { text: "コード設計の規約", link: "/code-design" },
+          { text: "データモデル", link: "/data-model" },
           { text: "テスト方針", link: "/testing" },
           { text: "UI設計の規約", link: "/ui-design" },
           { text: "v14移行チェックリスト", link: "/v14-migration" },

--- a/docs/active-effect.md
+++ b/docs/active-effect.md
@@ -12,6 +12,8 @@
 
 ## 属性キーの一覧
 使用を想定しているものの一覧です。現在は技能周りのみ。もっと変更できる箇所はありますが、動作確認していません。
+
+保存されている値の全体像は [データモデル](/data-model) にあります。
 ### 「【能力値】を使用する技能での判定」の修正
 `能力値`を対応する英単語に書き換えて使用してください。
 ##### ダイスボーナス：`system.characteristics.能力値.mod.bonus`
@@ -54,7 +56,7 @@
 - 鑑定：`appraisal`
 - 観察眼：`keenObservation`
 - 聞き耳：`listen`
-- 毒味：`taste`
+- 毒見：`taste`
 - 危機察知：`threatDetection`
 - 霊感：`spiritualSense`
 - 社交術：`etiquette`

--- a/docs/character-import.md
+++ b/docs/character-import.md
@@ -53,7 +53,7 @@
 - マッピング (Mapping): 3DM<=9 → レベル3
 - 直感 (Instinct): 2DM<=5 → レベル2
 - 観察眼 (Keen Observation): 1DM<=7 → レベル1
-- 毒味 (Taste): 1DM<=7 → レベル1
+- 毒見 (Taste): 1DM<=7 → レベル1
 - 強運 (Strong Luck): 1DM<=2 → レベル1（★マークのEX技能）
 
 ### メモ

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -94,7 +94,7 @@ feat: add resonance roll dialog
 ### 自動チェック
 
 - **pre-commitフック**: `npm install` 時に [lefthook](https://lefthook.dev/) がgitフックを自動セットアップし、コミット時にstagedファイルへBiomeが適用される（修正は自動でstageされる）。`.hbs` を触れば `check:templates`、`lang/*.json` を触れば `check:lang` も走る。緊急時は `git commit --no-verify` でスキップできるが非推奨
-- **CI**: pushとPRで GitHub Actions が Biome・テスト・ビルド・型チェック・翻訳/テンプレート整合チェックを実行する（`.github/workflows/ci.yml`）。マージにはCIが通ることが必要
+- **CI**: pushとPRで GitHub Actions が Biome・テスト・ビルド・型チェック・翻訳/テンプレート/スキーマ表の整合チェックを実行する（`.github/workflows/ci.yml`）。マージにはCIが通ることが必要
   - 型チェックジョブは本体ソース（`client/` + `common/`）をActions cacheで保持し、キャッシュミス時のみ `tools/fetch-foundry.mjs` がsecrets（`FOUNDRY_USERNAME` / `FOUNDRY_PASSWORD`）でfoundryvtt.comからNode配布版を取得する。フォークからのPRでは実行されない
 - **依存の更新**: DependabotがnpmとGitHub Actionsを週次で見る（`.github/dependabot.yml`）。パッチとマイナーは1本にまとめ、メジャーは個別にPRが立つ。**Biomeだけは3箇所（`package.json` / `biome.json` の `$schema` / `ci.yml` の `setup-biome`）を揃える必要がある**ので、Dependabotが上げてきたら残り2つを手で追従させる
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,0 +1,243 @@
+# データモデル
+
+アクター・アイテム・チャットメッセージが保存する値の一覧。スキーマの正は `module/data/` のコードで、このページはその読み方を説明するもの。**キーと日本語名の対応は `npm run check:schema-doc` が `module/config/` と突き合わせている**ので、綴りがずれたままになることはない。
+
+ActiveEffectでどのキーを変更できるかは [効果（ActiveEffect）](/active-effect) にある。
+
+## 登録されている種別
+
+| ドキュメント | 種別 | データモデル |
+|---|---|---|
+| Actor | `character` | `CharacterDataModel` |
+| Item | `weapon` | `WeaponDataModel` |
+| ChatMessage | `weapon` | `WeaponCardModel` |
+
+**種別は `system.json` の `documentTypes` と `CONFIG.*.dataModels` の両方に書く。** 片方だけでは噛み合わない。`documentTypes` に無い種別を `dataModels` に登録すると、作成できないのに `system` の型だけが増えて嘘になる（警告も出ない）。
+
+`npc` は `module/data/npc.ts` に定義だけが残っている。**登録していないので作成できない。** `EmokloreActor#system` を `CharacterDataModel` 固定で宣言しているため、登録すると型が嘘になる。NPCシートを作るときに合わせて決める（[ロードマップ](/roadmap) Phase 3）。
+
+## マイグレーション機構は無い
+
+`migrateData` / `shimData` / `LenientSchemaField` のいずれも実装しておらず、保存データにバージョンを刻んでもいない。つまり**configのキーを改名すると、古いデータは行き場を失ってそのまま残る**。
+
+キーを変えるときは値を移す仕組みを自分で書く必要がある。日本語の表示名を変えるだけなら `lang/ja.json` を直せばよく、キーは触らなくてよい。
+
+## Actor `character`
+
+### `system.resources`
+
+| パス | 型 | 既定 | 意味 |
+|---|---|---|---|
+| `resources.hp.value` | NumberField | 11 | 現在HP |
+| `resources.hp.max` | NumberField | 11 | 最大HP。**毎回上書きされる**（下の導出値を参照） |
+| `resources.mp.value` | NumberField | 2 | 現在MP |
+| `resources.mp.max` | NumberField | 2 | 最大MP。**毎回上書きされる** |
+| `resources.resonance.value` | NumberField | 1 | 共鳴値。1未満にはならない |
+| `resources.resonance.max` | NumberField | 9 | 共鳴値の上限。こちらは計算しないので手で決める |
+
+`hp.max` と `mp.max` はスキーマ上は書き込めるが、`prepareDerivedData` が能力値から計算し直すので書いた値は残らない。取り込みも書いているが、同じ理由で効いていない。
+
+### `system.characteristics.<能力値>`
+
+| パス | 型 | 制約 | 意味 |
+|---|---|---|---|
+| `characteristics.<k>.value` | NumberField | 1〜6、既定1 | 能力値 |
+| `characteristics.<k>.mod.bonus` | NumberField | 既定0 | ダイス数への修正 |
+| `characteristics.<k>.mod.success` | NumberField | 既定0 | 成功数への修正 |
+| `characteristics.<k>.mod.target` | NumberField | 既定0 | 目標値への修正 |
+
+`mod` の3つはシートから編集できない。ActiveEffectの適用先として存在している。この組は能力値・技能・基本技能・技能グループの4箇所に出てくるので `modifierField()` にまとめてある。
+
+キーは8種:
+
+| キー | 名前 |
+|---|---|
+| `physical` | 身体 |
+| `dexterity` | 器用 |
+| `mentality` | 精神 |
+| `sensitivity` | 五感 |
+| `intelligence` | 知力 |
+| `charisma` | 魅力 |
+| `sociality` | 社会 |
+| `fortune` | 運勢 |
+
+### `system.skills.<技能>`
+
+| パス | 型 | 制約 | 意味 |
+|---|---|---|---|
+| `skills.<k>.level` | NumberField | 0〜3、既定0 | 技能レベル。そのままダイス数になる |
+| `skills.<k>.characteristic` | StringField | 既定は定義の能力値 | 判定に使う能力値。**選べる技能にだけ `choices` が付く** |
+| `skills.<k>.specialization` | StringField | 既定 `""` | 特化。**特化を持つ技能にしかフィールドが無い** |
+| `skills.<k>.mod.*` | NumberField | 既定0 | 能力値と同じ3つ |
+
+`label` / `group` / `isExtra` は保存しない。`CONFIG.EMOKLORE` から引けるので、保存すると二重管理になるうえ、言語を切り替えたときに古い表示名が残る。
+
+`characteristic` の `choices` に入るのは翻訳済みの文字列ではなく**i18nキー**。描画時にテンプレートが `formInput` へ `localize=true` を渡して本体に解決させる。スキーマ定義の時点で `game.i18n` を呼ぶと、`i18nInit` より先に走ったときに壊れる。
+
+技能は35種。`★` は特殊技能（`isExtra`）、`特` は特化を持つもの。能力値が複数あるものは選択式。
+
+| キー | 名前 | 能力値 | グループ | |
+|---|---|---|---|---|
+| `search` | 検索 | 知力 | 調査系 | |
+| `insight` | 洞察 | 知力 | 調査系 | |
+| `mapping` | マッピング | 器用／五感 | 調査系 | |
+| `instinct` | 直感 | 精神 | 調査系 | |
+| `appraisal` | 鑑定 | 五感 | 調査系 | |
+| `keenObservation` | 観察眼 | 五感 | 知覚系 | |
+| `listen` | 聞き耳 | 五感 | 知覚系 | |
+| `taste` | 毒見 | 五感 | 知覚系 | |
+| `threatDetection` | 危機察知 | 五感／運勢 | 知覚系 | |
+| `spiritualSense` | 霊感 | 精神／運勢 | 知覚系 | ★ |
+| `etiquette` | 社交術 | 社会 | 交渉系 | |
+| `debate` | ディベート | 知力 | 交渉系 | |
+| `charm` | 魅了 | 魅力 | 交渉系 | |
+| `psychology` | 心理 | 精神／知力 | 交渉系 | |
+| `specializedKnowledge` | 専門知識 | 知力 | 情報系 | 特 |
+| `insider` | 事情通 | 五感／社会 | 情報系 | |
+| `industryKnowledge` | 業界 | 社会／魅力 | 情報系 | 特 |
+| `speed` | スピード | 身体 | 運動系 | |
+| `strength` | ストレングス | 身体 | 運動系 | |
+| `acrobatics` | アクロバット | 身体／器用 | 運動系 | |
+| `dive` | ダイブ | 身体 | 運動系 | |
+| `martialArt` | 武術 | 身体 | 運動系 | 特 |
+| `secretTechnique` | 奥義 | 身体／精神／器用 | 運動系 | ★特 |
+| `rangedAttack` | 射撃 | 器用／五感 | 運動系 | ★特 |
+| `endurance` | 耐久 | 身体 | 生存系 | |
+| `grit` | 根性 | 精神 | 生存系 | |
+| `medicine` | 医術 | 器用／知力 | 生存系 | |
+| `resurrection` | 蘇生 | 知力／精神 | 生存系 | ★ |
+| `technique` | 技巧 | 器用 | 特殊 | 特 |
+| `art` | 芸術 | 器用／精神／五感 | 特殊 | 特 |
+| `pilot` | 操縦 | 器用／五感／知力 | 特殊 | 特 |
+| `cipher` | 暗号 | 知力 | 特殊 | |
+| `computer` | 電脳 | 知力 | 特殊 | |
+| `stealth` | 隠匿 | 器用／社会／運勢 | 特殊 | |
+| `strongLuck` | 強運 | 運勢 | 特殊 | ★ |
+
+### `system.baseSkills.<基本技能>`
+
+| パス | 型 | 制約 | 意味 |
+|---|---|---|---|
+| `baseSkills.<k>.level` | NumberField | **1に固定**（min=max=1） | 基本技能はレベルを持たない |
+| `baseSkills.<k>.characteristic` | StringField | 定義の能力値 | `choices` は無く、選べない |
+| `baseSkills.<k>.mod.*` | NumberField | 既定0 | 能力値と同じ3つ |
+
+シートでは読むだけで編集できない。キーは13種:
+
+| キー | 名前 | 能力値 | グループ |
+|---|---|---|---|
+| `investigation` | 調査 | 器用 | 調査系 |
+| `perception` | 知覚 | 五感 | 知覚系 |
+| `negotiations` | 交渉 | 魅力 | 交渉系 |
+| `knowledge` | 知識 | 知力 | 情報系 |
+| `news` | ニュース | 社会 | 情報系 |
+| `athletic` | 運動 | 身体 | 運動系 |
+| `fight` | 格闘 | 身体 | 運動系 |
+| `throw` | 投擲 | 器用 | 運動系 |
+| `survival` | 生存 | 身体 | 生存系 |
+| `self` | 自我 | 精神 | 生存系 |
+| `treatment` | 手当て | 知力 | 生存系 |
+| `handiwork` | 細工 | 器用 | 特殊 |
+| `luck` | 幸運 | 運勢 | 特殊 |
+
+### `system.skillGroups.<グループ>`
+
+`mod` の3つだけを持つ。シートには出ず、ActiveEffectで「調査系すべてに+1」のようにまとめて修正するために存在する。
+
+| キー | 名前 |
+|---|---|
+| `investigation` | 調査系 |
+| `perception` | 知覚系 |
+| `negotiations` | 交渉系 |
+| `knowledge` | 情報系 |
+| `athletic` | 運動系 |
+| `survival` | 生存系 |
+| `unique` | 特殊 |
+
+グループは基本技能と同じ綴りのキーを使うが別のテーブルなので、表示名は「調査」と「調査系」のように異なる。
+
+### `system.emotions`
+
+`surface`（表）・`hidden`（裏）・`root`（ルーツ）の3つ。素の StringField だが、**入るのは共鳴感情のキー**（47種）で自由記述ではない。`choices` を付けていないのでスキーマは何も強制しないが、取り込みは対応表に無いラベルを保存しない。生の文字列を入れるとシートが未解決のi18nキーを表示する。
+
+感情属性は5種:
+
+| キー | 名前 |
+|---|---|
+| `desire` | 欲望 |
+| `passion` | 情念 |
+| `ideal` | 理想 |
+| `relationship` | 関係 |
+| `wound` | 傷 |
+
+### `system.biography`
+
+`age` / `gender` / `occupation` / `hometown` / `appearance` / `personality` / `background` / `importantPeople` / `likesAndDislikes` はいずれも素の StringField。`note` だけ HTMLField で、`system.json` の `htmlFields` に `biography.note` として宣言し、描画前に `enrichHTML` を通している。
+
+### 導出値（保存しない）
+
+計算は `module/rules/derived-values.ts` にあり、`prepareDerivedData` は配線だけを持つ。
+
+| 値 | 計算 |
+|---|---|
+| `skills.<k>.target` | 技能レベル ＋ 対応する能力値 |
+| `baseSkills.<k>.target` | 対応する能力値（`treatment` だけ半分・切り上げ） |
+| `resources.hp.max` | 10 ＋ 身体 |
+| `resources.mp.max` | 精神 ＋ 知力 |
+| `resources.resonance.value` | 1未満なら1に上げる |
+| `initiative` | 身体 ＋ スピードのレベル |
+
+`hp.value` / `mp.value` は `max` を超えないよう毎回丸める。
+
+**`initiative` だけはスキーマにフィールドが無い。** `declare` で型に足しているだけだが、`system.json` の `"initiative": "@initiative"` から参照されるので、消すとイニシアチブが振れなくなる。
+
+## Item `weapon`
+
+| パス | 型 | 制約 | 意味 |
+|---|---|---|---|
+| `skill` | StringField | `choices` は攻撃技能5種、既定 `fight` | 参照技能 |
+| `attackPower` | StringField | 既定 `""` | 武器攻撃力。**数値ではなく式** |
+| `range` | StringField | 既定 `""` | 射程。自由記述で、近接武器では使わない |
+| `notes` | HTMLField | | 備考。`htmlFields` に宣言済み |
+
+`attackPower` が文字列なのは、ルールブックが 肉体(1)・棒(2) と ナイフ(1D3)・拳銃(2D6) を同じ「武器攻撃力」として並べているため。`Roll.validate()` を通す独自バリデータが付いていて、式として読めない値は保存できない。
+
+派生値（`prepareDerivedData` が攻撃技能の定義から引く）:
+
+| 値 | 意味 |
+|---|---|
+| `rangeType` | `melee`（近接）か `ranged`（遠隔） |
+| `damageDie` | ダメージダイス。`d3` / `d6` / なし |
+| `usesBaseSkill` | 基本技能を参照するか |
+
+攻撃技能は5種:
+
+| キー | 名前 | 間合い | ダメージダイス | 基本技能 |
+|---|---|---|---|---|
+| `fight` | 格闘 | 近接 | d3 | 使う |
+| `martialArt` | 武術 | 近接 | d3 | 使わない |
+| `secretTechnique` | 奥義 | 近接 | d6 | 使わない |
+| `throw` | 投擲 | 遠隔 | なし | 使う |
+| `rangedAttack` | 射撃 | 遠隔 | なし | 使わない |
+
+## ChatMessage `weapon`
+
+武器カード。1枚のカードに攻撃判定とダメージを追記していくので、状態をメッセージ自身が持つ。
+
+| パス | 型 | 既定 | 意味 |
+|---|---|---|---|
+| `weaponName` | StringField | `""` | 使用時の武器名 |
+| `weaponImg` | StringField | `""` | 使用時の画像 |
+| `skill` | StringField | `fight` | 参照技能。アイテム側と違い `choices` は無い |
+| `attackPower` | StringField | `""` | 使用時の攻撃力の式 |
+| `rangeLabel` | StringField | `""` | 翻訳済みの間合い表示 |
+| `itemUuid` | DocumentUUIDField | `null` | 元の武器 |
+| `actorUuid` | DocumentUUIDField | `null` | 使ったアクター |
+| `successCount` | NumberField | `null` | 攻撃判定の成功数。`null` は「まだ振っていない」 |
+| `damageTotal` | NumberField | `null` | ダメージ合計。`null` は「まだ振っていない」 |
+
+**表示に要る値を使用時に焼き込んでいる**のは、あとで武器やアクターを消してもカードが読めるようにするため。`successCount` と `damageTotal` の `null` がそのままボタンの出し分けになる。
+
+## スキーマの外に保存しているもの
+
+`flags.emoklore.externalUrl` — キャラクター保管所から取り込んだときの元URL。取り込みが書く唯一のフラグで、どのスキーマにも属さない。

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -94,6 +94,12 @@ tests/live/
 
 翻訳キーの検査が独立している理由は、`check:lang`（ja/enの突き合わせ）でも `check:templates`（参照の検査）でも**テンプレート側の綴り間違いは見つからない**ため。実際に描いて画面を見るしかない。
 
+### ドキュメントの検査
+
+`check:schema-doc` は [データモデル](/data-model) と [効果（ActiveEffect）](/active-effect) が並べているキーと日本語名を、`module/config/` のテーブルおよび `lang/ja.json` と突き合わせる。**コードは型で綴りを守れるが、ドキュメントには型が無い**ので、同じ間違いがドキュメント側にだけ残る。実際この検査を書いた最初の実行で、〈毒見〉を「毒味」と書いた2箇所が見つかった（コード側の同じ誤記はPR #37で直っていた）。
+
+configのテーブルは型だけをimportしていてFoundryに依存しないため、Nodeが `.ts` をそのまま読める。`erasableSyntaxOnly` が型剥がし可能であることを保証しているので、ローダもビルドも要らない。
+
 ### CIで回さない理由
 
 **技術的にできないからではない。** CIはすでに `tools/fetch-foundry.mjs` で本体を落としており（`typecheck` ジョブ）、Chromeも `ubuntu-latest` に入っている。そのうえで見送っている。

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "prepare": "lefthook install",
     "check:lang": "node tools/check-lang.mjs",
     "check:templates": "node tools/check-templates.mjs",
+    "check:schema-doc": "node tools/check-schema-doc.mjs",
     "link:foundry": "node tools/create-symlinks.mjs",
     "typecheck": "node tools/typecheck.mjs",
     "verify:live": "node tests/live/run.mjs"

--- a/tools/check-schema-doc.mjs
+++ b/tools/check-schema-doc.mjs
@@ -1,0 +1,101 @@
+// docs のスキーマ表と module/config のテーブルがずれていないかチェックする
+// キーに添えた日本語名が lang/ja.json と食い違っていたら exit 1
+//
+// configのテーブルは型だけをimportしていてFoundryに依存しないので、Node がそのまま
+// .ts を読める（erasableSyntaxOnly が型剥がし可能であることを保証している）。
+// ビルドもローダも要らない
+import { readFileSync } from "node:fs";
+import { attackSkills } from "../module/config/attack-skills.ts";
+import { baseSkills } from "../module/config/base-skills.ts";
+import { characteristics } from "../module/config/characteristics.ts";
+import { emotionAttributes } from "../module/config/emotion-attributes.ts";
+import { resonantEmotions } from "../module/config/resonant-emotions.ts";
+import { skillGroups } from "../module/config/skill-groups.ts";
+import { skills } from "../module/config/skills.ts";
+
+const ja = JSON.parse(readFileSync("lang/ja.json", "utf-8"));
+const localize = (key) => key.split(".").reduce((node, part) => node?.[part], ja);
+
+// requireFullCoverage: 表として全キーを載せることを求めるもの。
+// 共鳴感情は47件あり、スキーマの参照ではなくデータの一覧なので、
+// 書かれている分の綴りだけ照合して網羅は求めない
+const TABLES = [
+  { name: "characteristics", table: characteristics, requireFullCoverage: true },
+  { name: "skillGroups", table: skillGroups, requireFullCoverage: true },
+  { name: "baseSkills", table: baseSkills, requireFullCoverage: true },
+  { name: "skills", table: skills, requireFullCoverage: true },
+  { name: "attackSkills", table: attackSkills, requireFullCoverage: true },
+  { name: "emotionAttributes", table: emotionAttributes, requireFullCoverage: true },
+  { name: "resonantEmotions", table: resonantEmotions, requireFullCoverage: false },
+];
+
+const DOCS = ["docs/data-model.md", "docs/active-effect.md"];
+
+// 同じキーが複数のテーブルに出る（investigation は基本技能と技能グループの両方、
+// fight は基本技能と攻撃技能の両方）。どのテーブルとして書かれていてもよいので、
+// キーに対して許容ラベルの集合を持つ
+const labelsByKey = new Map();
+const missingLabels = [];
+for (const { table, name } of TABLES) {
+  for (const [key, config] of Object.entries(table)) {
+    const label = localize(config.label);
+    if (label === undefined) {
+      missingLabels.push(`${name}.${key} → ${config.label}`);
+      continue;
+    }
+    if (!labelsByKey.has(key)) labelsByKey.set(key, new Set());
+    labelsByKey.get(key).add(label);
+  }
+}
+
+// 「キーと日本語名を並べている箇所」だけを照合する。表のセル（`|` 区切り）か、
+// 箇条書きの `名前：`key`` の形で、**区画まるごとがキー1つ**になっているものを拾う。
+// 既定値や本文でキー名に触れているだけの行（「既定 `fight`」など）は対象外
+const KEY_CELL = /^`([A-Za-z][A-Za-z0-9]*)`$/;
+const mismatches = [];
+const documented = new Set();
+
+for (const path of DOCS) {
+  const lines = readFileSync(path, "utf-8").split("\n");
+  lines.forEach((line, index) => {
+    // 表ではキーは必ず先頭の列。それ以外の列に出るキー名は既定値などの参照なので見ない
+    const cells = line.includes("|")
+      ? [line.split("|").find((cell) => cell.trim() !== "") ?? ""]
+      : [line];
+    for (const segment of cells.flatMap((cell) => cell.split(/[：:]/))) {
+      const matched = KEY_CELL.exec(segment.trim());
+      if (!matched) continue;
+      const key = matched[1];
+      const labels = labelsByKey.get(key);
+      if (!labels) continue;
+      documented.add(key);
+      if ([...labels].some((label) => line.includes(label))) continue;
+      mismatches.push(
+        `${path}:${index + 1} \`${key}\` の日本語名が合わない（正: ${[...labels].join(" / ")}）\n    ${line.trim()}`,
+      );
+    }
+  });
+}
+
+const uncovered = [];
+for (const { name, table, requireFullCoverage } of TABLES) {
+  if (!requireFullCoverage) continue;
+  const missing = Object.keys(table).filter((key) => !documented.has(key));
+  if (missing.length > 0) uncovered.push(`${name}: ${missing.join(", ")}`);
+}
+
+if (missingLabels.length > 0) {
+  console.error(`lang/ja.json に無いラベル: ${missingLabels.length}件`);
+  for (const entry of missingLabels) console.error(`  - ${entry}`);
+}
+if (mismatches.length > 0) {
+  console.error(`ドキュメントとconfigで日本語名が食い違う: ${mismatches.length}件`);
+  for (const entry of mismatches) console.error(`  - ${entry}`);
+}
+if (uncovered.length > 0) {
+  console.error(`ドキュメントに載っていないキー:`);
+  for (const entry of uncovered) console.error(`  - ${entry}`);
+}
+
+if (missingLabels.length + mismatches.length + uncovered.length > 0) process.exit(1);
+console.log(`schema doc OK: ${documented.size}件のキーが config と一致`);


### PR DESCRIPTION
#49 に積む（baseは `refactor/naming-conventions`）。保存する値の一覧を起こし、それがコードとずれないよう検査を足した。

## なぜ必要だったか

`docs/` にスキーマの文書化は無く、`active-effect.md` が `mod` の4系統だけを手書きで写している状態だった（全体の約4割）。同ページ自身が「もっと変更できる箇所はありますが、動作確認していません」と穴を認めている。

そして**ドキュメントは実際にずれていた**。`code-design.md` は〈毒見〉の誤記をPR #37で直したことを「型で防げる種類の間違いだった」と書いているが、**その同じ誤記がドキュメント側には2箇所残っていた**（`active-effect.md` と `character-import.md` の散文が「毒味」）。コードは型で守られたが、ドキュメントには型が無い。

## docs/data-model.md

3つのサブタイプのフィールドを、型・制約・意味つきで並べた。あわせて次を書いた。

- 種別は `system.json` の `documentTypes` と `CONFIG.*.dataModels` の**両方**に書かないと噛み合わないこと
- **マイグレーション機構が存在しないこと**。`migrateData` / `shimData` / `LenientSchemaField` のいずれも無く、バージョンも刻んでいないので、configのキーを改名すると古いデータは行き場を失って残る
- `hp.max` / `mp.max` は保存されるが毎回上書きされること。逆に `initiative` は**スキーマにフィールドが無い**のに `system.json` の `"initiative": "@initiative"` から参照される公開契約であること
- `attackPower` が数値ではなく式である理由（ルールブックが 肉体(1) と ナイフ(1D3) を同じ「武器攻撃力」として並べている）
- どのスキーマにも属さない `flags.emoklore.externalUrl`

## tools/check-schema-doc.mjs

`check-lang.mjs` と同じ形（2つの集合を作って差分を出し、あれば exit 1）。

**configのテーブルは型だけをimportしていてFoundryに依存しないので、Nodeが `.ts` をそのまま読める。** `erasableSyntaxOnly` が型剥がし可能であることを保証しているため、ローダもビルドも要らない。

照合するのは「キーと日本語名を並べている箇所」だけに絞った。表なら先頭の列、箇条書きなら `名前：キー` の形で、区画まるごとがキー1つのもの。既定値として `fight` に触れているだけの行を誤検出しないようにするため（実際に3件の誤検出が出たので絞り込んだ）。

**キーの改名とラベルの書き間違いの両方でNGになることを確認済み。** 現在62件のキーを照合している。

## 検証

`npm run check:schema-doc` が通る。lint / typecheck / test 115件 / check:lang / check:templates / docs:build も通る。スキーマの記述を変えただけで実行時の挙動は変わっていないため、このPRでは実機検証を回していない（#49 までで23件通過済み）。