### PR TITLE
棚卸しで見つかった食い違いを直し、ドキュメントを実測値に合わせる

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       # package.json の @biomejs/biome と揃えること
       - uses: biomejs/setup-biome@v2
         with:
-          version: 2.5.4
+          version: 2.5.5
       - run: biome ci .
 
   build:

--- a/css/components/data-table.css
+++ b/css/components/data-table.css
@@ -24,7 +24,7 @@
 
   .em-data-table__head {
     height: 28px;
-    margin: 2px 0;
+    margin: var(--spacer-2) 0;
     padding: 0;
     background: var(--emoklore-surface-sunken);
     font-weight: bold;
@@ -32,12 +32,12 @@
   }
 
   .em-data-table__head > * {
-    font-size: 14px;
+    font-size: var(--font-size-14);
     text-align: center;
   }
 
   .em-data-table__row {
-    padding: 0 2px;
+    padding: 0 var(--spacer-2);
     border-bottom: 1px solid var(--color-border);
   }
 
@@ -57,7 +57,7 @@
     align-items: center;
     margin: 0;
     overflow: hidden;
-    font-size: 13px;
+    font-size: var(--font-size-13);
     text-align: left;
   }
 
@@ -71,7 +71,7 @@
   }
 
   .em-data-table__control {
-    font-size: 12px;
+    font-size: var(--font-size-12);
     text-align: center;
     margin: 0 6px;
   }

--- a/css/components/field-list.css
+++ b/css/components/field-list.css
@@ -11,13 +11,12 @@
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    gap: 0px;
   }
 
   /* 短い値はラベルと横に並べる */
   .em-field--inline {
     flex-direction: row;
-    gap: 8px;
+    gap: var(--spacer-8);
   }
 
   .em-field__label {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,7 +43,9 @@ lang/                … ja.json が正、en.json は追従
 | `emoklore.preApplyDamage` | `(actor, amount, updates)` | できる |
 | `emoklore.applyDamage` | `(actor, amount)` | — |
 
-`config` はその場で組み立てた設定オブジェクトをそのまま渡しているので、フックの中で書き換えれば判定内容を差し替えられる。攻撃判定なら `skill` と `base`、ダメージなら `successCount` / `damageDie` / `attackPower` / `bonus`。`preApplyDamage` の `updates` も同じく、そのまま `Actor#update` に渡る更新データなので書き換えが効く。
+`config` はその場で組み立てた設定オブジェクトをそのまま渡しているので、フックの中で書き換えれば判定内容を差し替えられる。攻撃判定なら `skill`、ダメージなら `successCount` / `damageDie` / `attackPower` / `bonus`。`preApplyDamage` の `updates` も同じく、そのまま `Actor#update` に渡る更新データなので書き換えが効く。
+
+**攻撃判定の `config` に `base`（基本技能かどうか）は載せていない。** これは `skill` から一意に決まる値なので、両方を載せると「通常技能のキーに `base: true`」のような矛盾した対をフックの側から作れてしまう。実際、以前は `base` をフックの**前**に算出しており、`skill` だけを差し替えると差し替え前の `base` と組み合わされて技能値が拾えなくなっていた。いまはフックの後に `resolveAttackSkill()` から引き直している。
 
 カードのボタンは `WeaponCardModel.ACTIONS` の表で `data-action` から引いている。モジュールがここにキーを足せば、テンプレートを差し替えずにボタンを増やせる。
 
@@ -74,9 +76,7 @@ Foundryは `Document#update` をサーバ側で権限検査するので、OWNER�
 3. **`config/` の副作用**: `module/config/index.ts` が import 時に `preLocalize` を呼び、`performPreLocalization` が `CONFIG.EMOKLORE` を破壊的に書き換える。この表の「`config/` に置かないもの」に反するが、dnd5e / draw-steel 由来の確立したパターンなので当面は踏襲する
 4. **`documents/` から `applications/` への逆依存**: `module/documents/actor.ts` が `promptResonanceRoll` をimportし、`rollResonance` の中で呼んでいる。「引数が無ければUIを開く」という判断はプレゼンテーションの決定なので、下の表の「`documents/` に置かないもの: ダイアログ」に反する。シート側で入力を解決してから渡す形にすれば矢印が反転する
 5. **`utils/` が雑多**: 純粋なパーサ（`charsheet-importer`）、i18n機構（`localization`）、チャットI/O（`chat`）、DOM・Documentのアダプタ（`sheet` `targets` `queries`）が同居している。特に `queries.ts` は `actor.applyDamage()` を呼ぶオーケストレータで、ユーティリティではない。**この逆依存は `import type` のせいでimportグラフに現れない**
-6. **攻撃技能の引き方が3箇所で食い違う**: 未知の技能キーに対し `data/item-models.ts` は `attackSkills.fight`（近接・d3）に倒れるが、`data/messages/weapon-card.ts` は `base: false` / `damageDie: null`（遠隔相当）になる。同じ入力に別の答えを返す。`resolveAttackSkill()` に寄せれば重複と食い違いが同時に消える
-7. **同じ定数を2箇所で宣言**: 技能レベルの範囲は `data/character.ts` の `SKILL_LEVEL_MIN` / `SKILL_LEVEL_MAX` が正のはずだが、`utils/charsheet-importer.ts` がローカルに同じ値を持っている。シート側は正しくimportしている
-8. **CIの穴**: 型チェックジョブはフォークからのPRで実行されない（Actions cacheがフォークから復元できるため）。lefthookにも型チェックは入っていないので、**フォークからのPRは型チェックを一度も通さずに緑になれる**（Issue #7 の範囲）
+6. **CIの穴**: 型チェックジョブはフォークからのPRで実行されない。理由は2つ重なっており、Actions cacheがフォークから復元できないことと、secretsがフォークPRに渡らないのでキャッシュミス時の `tools/fetch-foundry.mjs` 経路も成立しないこと。lefthookには型チェックもテストも入っていない（`pre-push` 自体が無い）ので、**フォークからのPRは型チェックを一度も通さずに緑になれる**（Issue #7 の範囲）
 
 `weapon` は `documentTypes.Item.weapon` の宣言で到達可能にした（`game.documentTypes.Item` が `["base", "weapon"]` を返すことを実機で確認済み）。**新しい種別を足すときは、データモデルの登録だけでなく `system.json` の宣言が要る。**
 
@@ -95,6 +95,8 @@ Phase 2 のあとに解消したもの:
 - ~~**`as unknown as` の二重キャスト**~~: `character-sheet.ts` の5箇所を解消し、`tools/no-double-cast.grit`（BiomeのGritQLプラグイン）で再発を禁止した。本体APIとの境界に残る5箇所は理由付きで個別抑制している
 - ~~**`strict: false`**~~: 全フラグを計測したところエラー0件だったので `strict: true` にし、`noImplicitReturns` / `exactOptionalPropertyTypes` / `noUnusedLocals` / `noUnusedParameters` も足した
 - ~~**`rules/` から `utils/` への逆依存**~~: `formatDMPart` を `rules/skill-roll.ts` に取り込み、`rules/` を自己完結させた。`documents/` にあった表示整形（`formatSkillName`）は `utils/chat.ts` へ移した
+- ~~**攻撃技能の引き方が食い違う**~~: 未知のキーに対する倒し先が4箇所（`data/item-models.ts`、`data/messages/weapon-card.ts` の2箇所、`utils/weapon.ts`）でばらばらで、`base` は真偽が逆、`damageDie` は `d3` と `null` に割れていた。`utils/weapon.ts` の `resolveAttackSkill()` に寄せ、型述語 `isAttackSkillKey` を表の隣（`config/`）に置いた
+- ~~**同じ定数を2箇所で宣言**~~: 技能レベルの範囲を `utils/charsheet-importer.ts` がローカルに書き写していた。`rules/limits.ts` を新設して能力値と技能レベルの範囲をまとめ、`data/` `applications/` `utils/` の3層が同じ源を引くようにした。`data/` に置いたままでは層のimport方向（`utils/` → `data/` は型のみ）に阻まれて取り込み側が値を引けないのが、書き写しの原因だった
 
 型設計の見直しで解消したもの（規約は [コード設計の規約](/code-design) が正）:
 

--- a/docs/code-design.md
+++ b/docs/code-design.md
@@ -179,11 +179,13 @@ FoundryVTT本体はJSDocで型を持つが、実行時に定義されるプロ�
 |---|---|---|
 | `noPropertyAccessFromIndexSignature` | 28件 | ほぼ全部 `dataset.rollType` → `dataset['rollType']`。DOMのdatasetに対して読みにくくなるだけ |
 | `lib: ES2025` / `ESNext` | 1件 | 武器カードの `parent` のキャストが comparability を失う（`weapon-card.ts` の `this.parent as CardMessage`）。ES2024までは0件なので、そちらに固定している。二重キャストは禁止しているので、直すなら型述語か構造の側 |
-| `checkJs` + `tools/` `tests/` を `include` | 99件 | 内訳は `tests/live/` 78件・`tools/` 21件。前者はページに注入するグローバル（`__waitFor` など）とコールバックの暗黙 `any` で、型を付けるには注入側の宣言が要る。後者には `create-symlinks.mjs` の `value` が `undefined` になりうるなど**実在する取りこぼし**も混じっているので、別途拾う価値がある |
+| `checkJs` + `tools/` `tests/` を `include` | 99件 | 内訳は `tests/live/` 78件・`tools/` 21件（`tools/` は再計測時点で27件）。どちらもページに注入するグローバル（`__waitFor` など）とコールバックの暗黙 `any` が大半で、型を付けるには注入側の宣言が要る |
 | `types: ["node"]` の分離 | — | ブラウザ向けコードにNodeのグローバルが載るが、ルートの `vite.config.ts` が同じ `include` にあるため tsconfig を分ける必要がある |
 | Biome `preset: all` | 700件超 | `useNamingConvention` 116 / `noMagicNumbers` 51 / `noConsole` 36 / `noTernary` 26 と、大半がノイズ |
 | Biome `noUnnecessaryConditions` | — | `actor-sheet` の `switch` を unreachable と誤検出する。Biomeは型情報を持たないため `dataset.rollType` を推論できない。**実機で3経路とも通ることを確認済み** |
 | Biome `useAwait` | 7件 | 本体API契約上 `async` が必須のハンドラを咎める |
 | Biome `useImportExtensions` | 90件 | bundlerの解決方式と噛み合わない |
+
+`tools/` の `checkJs` については、かつてここに「`create-symlinks.mjs` の `value` が `undefined` になりうるなど**実在する取りこぼし**が混じっている」と書いていたが、**これは誤りだったので撤回する**。27件を1件ずつ当たった結果、内訳は暗黙 `any` の注釈不足（TS7006 が10件ほか）と `catch` の `unknown`（TS18046 が2件）と `const config = {}` の索引付け（TS2339 / TS7053）で、**実行時に壊れるものは1件も無かった**。名指しされていた `value` も、直前の正規表現が `(.+?)` でマッチ済みなので `undefined` にはならない。件数だけ見て「この中に本物がある」と推定したのが間違いで、**件数は当たるべき対象の量であって、中身の証拠ではない**。
 
 Biomeは型情報を持たないので、型に関する検査はすべて `tsc` 側にある。組み込みルールに無いものは**GritQLプラグインで書けることがある**（二重キャストの禁止がそれ）。「Biomeでは無理」と決める前にプラグインを検討すること。

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -73,18 +73,20 @@ v14専用に移行します（v13サポートは打ち切り）。
 | `chip.css` | 5 | 4 |
 | `character-sheet.css` | 8 | 5 |
 | `meter.css` | 11 | 4 |
-| `field-list.css` | 3 | 0 |
-| `data-table.css` | 14 | 0 |
+| `field-list.css` | 2 | 1 |
+| `data-table.css` | 12 | 5 |
+
+`field-list.css` と `data-table.css` の数字は、等値なものをトークンに置き換えたあとの再計測（`margin` / `padding` / `gap` / `font-size` を数えている）。残りは丸め先の判断が要るもの。
 
 優先度の高い順に、残っている不揃いは次のとおり。
 
-1. **フォントサイズの単位がばらばら** — `meter.css` と `data-table.css` に `1.1em` / `0.8em` / `1.5rem` / `14px` / `13px` / `12px` / `font-size: small` が混在する。4種類の単位系が同居していて、特に `small` は実寸がブラウザ依存。本体は `--font-size-10` から `--font-size-80` まで17段を持ち、`12px` / `13px` / `14px` はそのまま対応するトークンがある。機械的に置き換えられるので最初に片付けたい
-2. **角丸が本体と噛み合っていない** — 自前は 5px / 2px / 10px を定義しているが、本体で最も多いのは 4px（34箇所）、次いで 3px（26）。実際、変数を使わず直書きした2箇所（`data-table.css` の 3px、`sidebar.css` の 4px）はどちらも本体寄りの値を選んでおり、変数のほうが浮いている。値を本体に寄せるかどうかの判断が要る
-3. **`data-table.css` と `field-list.css` が丸ごと手つかず** — 効果タブと経歴タブ。`5px` / `10px` / `20px` など本体のスケール（2/4/8/12/16）に無い値が残る
-4. **経歴タブが本体と綱引きしている** — `character-sheet.css` が `.standard-form` の `.form-group` を `flex-direction: column; gap: 0px` で丸ごと打ち消している。ダイアログを `standard-form` に載せて手書きを減らしたのと逆方向の状態がここだけ残る。本体には `.form-group.stacked` があるので寄せられるかもしれない
-5. **`min-width: 601px` の根拠が不明** — 既定幅を760pxに広げ、サイドバーも畳めるようになった今、この下限が妥当かは未検証
+1. ~~**フォントサイズの単位がばらばら**~~ — 等値で置換できる分は対応済み。`data-table.css` の `14px` / `13px` / `12px` を `--font-size-14` / `-13` / `-12` にした。**残るのは `meter.css` の4件で、いずれも丸めの判断が要る**。`1.1em`（継承14pxに対し15.4px。トークンは15と16しかない）、`0.8em`（11.2px）、`small`（≒13pxだが絶対キーワードなので親の `1.1em` の影響を受けず、トークン化すると親子関係が変わる）、`1.5rem`（`--font-size-24` と等値だが直上の `--button-size: 2.25rem` と釣り合っており、トークン化すると狭幅でグリフだけ縮む）
+2. **角丸が本体と噛み合っていない** — 自前は 5px / 2px / 10px を定義しているが、本体で最も多いのは 4px（34箇所）、次いで 3px（26）、2px（16）、5px（13）、10px（3）。**本体には角丸のCSS変数が1つも無い**（`--*radius*` は0件）ので、これは他の項目と違って「本体トークンに寄せる」解が存在せず、生値を本体の分布に寄せるかどうかの判断にしかならない。分布を見ると 5px も本体に13箇所あり、浮いているのは実質 `10px` だけ。変数を使わず直書きしているのは4箇所（`data-table.css` の 3px、`sidebar.css` の 4px、`weapon-sheet.css` の 4px、`weapon-card.css` の 4px）
+3. **`data-table.css` と `field-list.css` に本体スケール外の値が残る** — 効果タブと経歴タブ。等値な `2px` / `8px` は `--spacer-2` / `-8` にしたが、`5px` / `6px` / `10px` / `20px` など本体のスケール（2/4/8/12/16）に無い値は丸め先の判断が要るので残してある。あわせて `data-table.css` の `height: 28px`（文字が入る箱の固定px）と `grid-template-columns` の `70px`（アイコンボタン2個ぶん。`--button-size` から導けるか）も判断待ち
+4. **経歴タブが本体と綱引きしている** — `character-sheet.css` が `.standard-form` の `.form-group` を `flex-direction` / `align-items` / `gap` の3プロパティで打ち消し、さらに `.form-group.stacked` で `flex-direction: row` に戻している（本体の stacked は `flex-wrap` と子の `flex: 0 0 100%` で成立するので、column にすると壊れるため）。打ち消しの打ち消しになっている。本体の `.form-group.stacked` は実在し（`formGroup` ヘルパが `stacked` を受ける）、`biography.hbs` の `formGroup` に `stacked=true` を渡せばCSSの2ブロックを丸ごと削除できる。**ただしラベルと入力の間に本体の `gap: 0.5rem`（8px）が入るので見た目が変わる**。現状10項目のうち HTMLField の `note` だけ本体が自動で stacked を付けている
+5. **`min-width: 601px` が妥当か未検証** — 根拠は履歴から判明した。`3ab0fcd`（2025-10-11）で **既定幅そのもの**として 601 が入り（当時は横に一切縮められない設定だった）、`a5070ee` で既定幅を760pxに変えたときに据え置かれた。**内容の実寸から導いた下限ではない。** サイドバー250pxと padding 32px を引くとタブ側に残るのは約317pxで、そこで破綻しないかは実機でしか決まらない
 
-`gap: 0px` が3箇所あるが、これはマジックナンバーというより本体の `standard-form` が入れる間隔を打ち消した跡で、4番と同じ話に含まれる。
+`gap: 0px` は2箇所。`character-sheet.css` のものは4番の打ち消しの一部だが、`field-list.css` にあったものは打ち消す対象が無い no-op だったので削除した。
 
 ### 正式版に向けて
 

--- a/module/applications/character-sheet.ts
+++ b/module/applications/character-sheet.ts
@@ -1,10 +1,4 @@
 import { systemPath } from "../constants";
-import {
-  CHARACTERISTIC_MAX,
-  CHARACTERISTIC_MIN,
-  SKILL_LEVEL_MAX,
-  SKILL_LEVEL_MIN,
-} from "../data/character";
 import type { EmokloreActor } from "../documents/actor";
 import type { EmokloreItem } from "../documents/item";
 import {
@@ -13,6 +7,12 @@ import {
   calculateTotalSkillPoints,
   SKILL_POINT_MAX,
 } from "../rules/character-points";
+import {
+  CHARACTERISTIC_MAX,
+  CHARACTERISTIC_MIN,
+  SKILL_LEVEL_MAX,
+  SKILL_LEVEL_MIN,
+} from "../rules/limits";
 import { getSetting, setSetting } from "../settings";
 import { prepareActiveEffectCategories } from "../utils/effects";
 import { typedEntries } from "../utils/object";

--- a/module/config/attack-skills.ts
+++ b/module/config/attack-skills.ts
@@ -56,6 +56,14 @@ const definitions = {
 
 export type AttackSkillKey = keyof typeof definitions;
 
+/**
+ * 攻撃技能のキーかどうか。
+ *
+ * 武器カードの skill は choices を持たない StringField なので、保存データやフックが
+ * 宣言した型を裏切りうる。引く前にここを通す
+ */
+export const isAttackSkillKey = (value: string): value is AttackSkillKey => value in definitions;
+
 // satisfies だけだと各値が個別の狭い型に推論されるため、値の型は AttackSkillConfig に揃える。
 // キーは literal のまま保たれるので AttackSkillKey が使える
 export const attackSkills: Record<AttackSkillKey, AttackSkillConfig> = definitions;

--- a/module/data/character.ts
+++ b/module/data/character.ts
@@ -11,23 +11,18 @@ import {
   clampToMax,
   normalizeResonance,
 } from "../rules/derived-values";
+import {
+  CHARACTERISTIC_MAX,
+  CHARACTERISTIC_MIN,
+  SKILL_LEVEL_MAX,
+  SKILL_LEVEL_MIN,
+} from "../rules/limits";
 import type { SkillRollParams } from "../rules/skill-roll";
 import type { ModifierSet } from "../rules/types";
 import { typedEntries } from "../utils/object";
 import { EmokloreSystemDataModel } from "./system-model";
 
 const { HTMLField, NumberField, SchemaField, StringField } = foundry.data.fields;
-
-/**
- * 能力値と技能レベルの取りうる範囲。
- *
- * スキーマのバリデーションと、シートの段入力（何段出すか）の両方がこれを見る。
- * 別々に書くと片方だけ変えたときに黙ってずれるので、ここを正にする。
- */
-export const CHARACTERISTIC_MIN = 1;
-export const CHARACTERISTIC_MAX = 6;
-export const SKILL_LEVEL_MIN = 0;
-export const SKILL_LEVEL_MAX = 3;
 
 /**
  * どの技能を振るか。

--- a/module/data/item-models.ts
+++ b/module/data/item-models.ts
@@ -1,10 +1,10 @@
 import {
   type AttackSkillKey,
   attackSkillChoices,
-  attackSkills,
   type DamageDie,
   type RangeType,
 } from "../config/attack-skills";
+import { resolveAttackSkill } from "../utils/weapon";
 import { EmokloreSystemDataModel } from "./system-model";
 
 const { HTMLField, StringField } = foundry.data.fields;
@@ -64,9 +64,7 @@ export class WeaponDataModel extends EmokloreSystemDataModel {
   override prepareDerivedData() {
     super.prepareDerivedData();
 
-    // 技能が未知のキーなら近接の既定に倒す。choices で弾かれるはずだが、
-    // 手書きのデータやCONFIGを触るモジュールで壊れないようにしておく
-    const config = attackSkills[this.skill] ?? attackSkills.fight;
+    const config = resolveAttackSkill(this.skill);
 
     this.rangeType = config.rangeType;
     this.damageDie = config.damageDie;

--- a/module/data/messages/weapon-card.ts
+++ b/module/data/messages/weapon-card.ts
@@ -1,4 +1,4 @@
-import { type AttackSkillKey, attackSkills } from "../../config/attack-skills";
+import type { AttackSkillKey } from "../../config/attack-skills";
 import type { EmokloreActor } from "../../documents/actor";
 import { buildDamageFormula } from "../../rules/weapon-damage";
 import { createDamageAppliedMessage } from "../../utils/chat";
@@ -7,6 +7,7 @@ import { resolveTargetActors } from "../../utils/targets";
 import {
   type CardButtons,
   renderWeaponCard,
+  resolveAttackSkill,
   resolveCardButtons,
   type WeaponCardState,
 } from "../../utils/weapon";
@@ -108,12 +109,15 @@ export class WeaponCardModel extends EmokloreSystemDataModel {
       return;
     }
 
-    const config = { skill: this.skill, base: attackSkills[this.skill]?.base ?? false };
+    // base は skill から決まるので config に載せない。両方を載せると、skill だけを
+    // 差し替えるフックが「通常技能のキーに base: true」のような対を作れてしまう
+    const config = { skill: this.skill };
     if (Hooks.call("emoklore.preRollAttack", this.message, config) === false) return;
 
     // skill はカードに焼き込んだ保存データで、フックで差し替えられてもいる。
-    // 宣言した型（AttackSkillKey）を裏切りうるので、判定に渡す前に確かめる
-    const ref = resolveSkillRef(config.skill, { base: config.base });
+    // 宣言した型（AttackSkillKey）を裏切りうるので、判定に渡す前に確かめる。
+    // base を引くのはフックの後。先に引くと差し替え前の技能の答えを使うことになる
+    const ref = resolveSkillRef(config.skill, { base: resolveAttackSkill(config.skill).base });
     if (!ref) {
       ui.notifications?.warn("EMOKLORE.ChatMessage.weapon.UnknownSkill", { localize: true });
       return;
@@ -132,7 +136,7 @@ export class WeaponCardModel extends EmokloreSystemDataModel {
     const config = {
       // canRollDamage が成功数の非nullを保証している
       successCount: this.successCount as number,
-      damageDie: attackSkills[this.skill]?.damageDie ?? null,
+      damageDie: resolveAttackSkill(this.skill).damageDie,
       attackPower: this.attackPower,
       // 〈ストレングス〉加算の接続点。近接なら技能レベルを渡す想定だが、いまは常に0
       bonus: 0,

--- a/module/rules/limits.ts
+++ b/module/rules/limits.ts
@@ -1,0 +1,15 @@
+/**
+ * 能力値と技能レベルの取りうる範囲。
+ *
+ * スキーマのバリデーション（data/）、シートの段入力が何段出すか（applications/）、
+ * 取り込んだ値のクランプ（utils/）の3層がこれを見る。別々に書くと片方だけ変えたときに
+ * 黙ってずれるので、ここを正にする。
+ *
+ * data/ ではなく rules/ に置いてあるのは層のimport方向のため。utils/ から data/ は
+ * 型のみ参照できる決まりなので（docs/code-design.md の層表）、data/ に置くと
+ * 取り込み側が値を引けず、実際 charsheet-importer が同じ値を手で書き写していた。
+ */
+export const CHARACTERISTIC_MIN = 1;
+export const CHARACTERISTIC_MAX = 6;
+export const SKILL_LEVEL_MIN = 0;
+export const SKILL_LEVEL_MAX = 3;

--- a/module/utils/charsheet-importer.ts
+++ b/module/utils/charsheet-importer.ts
@@ -1,4 +1,5 @@
 import type { EmokloreActor } from "../documents/actor";
+import { SKILL_LEVEL_MAX, SKILL_LEVEL_MIN } from "../rules/limits";
 import { typedEntries } from "./object";
 
 /**
@@ -104,10 +105,6 @@ export function parseEmotions(memo: string, index: Record<string, string>): Pars
  * 全角・半角も両方受ける。
  */
 const SPECIALIZATION_PATTERN = /^(.+?)\s*(?:[（(]\s*(.*?)\s*[）)]|[：:]\s*(.*))$/;
-
-/** 技能レベルの下限・上限。スキーマの skills.*.level と揃える */
-const SKILL_LEVEL_MIN = 0;
-const SKILL_LEVEL_MAX = 3;
 
 export type ParsedSkills = {
   /** 技能キー → レベル */

--- a/module/utils/weapon.ts
+++ b/module/utils/weapon.ts
@@ -6,15 +6,28 @@
  */
 
 import {
+  type AttackSkillConfig,
   type AttackSkillKey,
   attackSkills,
   type DamageDie,
+  isAttackSkillKey,
   type RangeType,
 } from "../config/attack-skills";
 import { systemPath } from "../constants";
 import { canRollDamage } from "../rules/weapon-damage";
 
 const CARD_TEMPLATE = systemPath("templates/chat/weapon-card.hbs");
+
+/**
+ * 攻撃技能の定義を引く。未知のキーは近接の既定（〈＊格闘〉）に倒す。
+ *
+ * 未知のキーが来る経路は3つある。手書き・移行データ、CONFIG.EMOKLORE.attackSkills から
+ * キーを消したモジュール、そして emoklore.preRollAttack で skill を差し替えるモジュール。
+ * かつては引く側が4箇所それぞれに ?? を書いており、同じ入力に対して base が真偽で
+ * 食い違い、damageDie が d3 と null に割れていた。倒し先はここだけが決める
+ */
+export const resolveAttackSkill = (skill: string): AttackSkillConfig =>
+  isAttackSkillKey(skill) ? attackSkills[skill] : attackSkills.fight;
 
 /** 間合いの表示名。「近接」「遠隔」 */
 export const localizeRangeType = (rangeType: RangeType): string =>
@@ -26,8 +39,8 @@ export const localizeRangeType = (rangeType: RangeType): string =>
  * attackSkills の label は preLocalize の対象外（スキーマの choices と共有しているため）
  * なので、翻訳は引く側で行う。
  */
-export const localizeAttackSkill = (skill: AttackSkillKey): string =>
-  game.i18n.localize(attackSkills[skill]?.label ?? "");
+export const localizeAttackSkill = (skill: string): string =>
+  game.i18n.localize(resolveAttackSkill(skill).label);
 
 /**
  * 武器の射程の表示。

--- a/tests/live/checks/weapon.mjs
+++ b/tests/live/checks/weapon.mjs
@@ -170,4 +170,54 @@ export async function run({ page, check }) {
   );
 
   await pinDice(page, DICE.alwaysHit);
+
+  // base は skill から引き直さないと、フックが技能を差し替えたときに
+  // 差し替え前の base と組み合わされる（docs/architecture.md の武器カードのフック）。
+  // 通常技能から基本技能へまたぐ差し替えでしか出ないので、境界をまたがせる
+  await check("フックが技能を差し替えても基本技能の別が食い違わない", () =>
+    assertInPage(
+      page,
+      async (tag) => {
+        const a = game.actors.getName(`${tag}_char`);
+        // 刀は martialArt（通常技能）。これを throw（基本技能）に差し替える
+        const hookId = Hooks.on("emoklore.preRollAttack", (_message, config) => {
+          config.skill = "throw";
+        });
+
+        try {
+          const msg = await a.items.getName(`${tag}_刀`).use();
+          const id = msg.id;
+          await window.__waitFor(() => game.messages.get(id), { label: "武器カードの作成" });
+
+          await game.messages.get(id).system.rollAttack();
+          const card = await window.__waitFor(
+            () => {
+              const sys = game.messages.get(id).system;
+              return sys.successCount === null ? null : sys;
+            },
+            { soft: true, label: "差し替え後の攻撃判定" },
+          );
+
+          if (!card) {
+            // 差し替え前の base（false）で基本技能の表を引けず、判定が飛ばなかった
+            return { ok: false, detail: "差し替え後に判定が飛ばず successCount が null のまま" };
+          }
+
+          const roll = game.messages.get(id).rolls.at(-1);
+          const expected = a.system.baseSkills.throw.target;
+          // em はカスタムDieの修飾子なので、目標値の指定だけを見る
+          const ok = roll.terms[0].faces === 10 && roll.formula.endsWith(`<=${expected}`);
+          return {
+            ok,
+            detail: ok
+              ? `〈＊投擲〉の目標値${expected}で振られた（${roll.formula}）`
+              : `目標値が基本技能側でない: ${roll.formula}（期待 <=${expected}）`,
+          };
+        } finally {
+          Hooks.off("emoklore.preRollAttack", hookId);
+        }
+      },
+      TAG,
+    ),
+  );
 }


### PR DESCRIPTION
積みタスクを棚卸しし、小さく直せるものをまとめた。大きいものは別途Issueにする。

`rules/limits.ts` を新設し、能力値と技能レベルの範囲をそこにまとめた。`charsheet-importer.ts` が同じ値をローカルに書き写しており、コメント自身が「スキーマと揃える」と自認しているのに import していなかった。原因は層のimport方向で、`utils/` から `data/` は型のみ参照できる決まりなので、`data/` に置いたままでは取り込み側が値を引けなかった。

未知の攻撃技能キーに対する倒し先を `resolveAttackSkill()` に寄せた。同じ入力に4箇所が別の答えを返しており、`base` は真偽が逆、`damageDie` は `d3` と `null` に割れていた。`architecture.md` は3箇所と書いていたが、実際は `utils/weapon.ts` のラベルを含めて4箇所だった。

**`preRollAttack` が技能を差し替えると判定が壊れる不具合を直した。** `base` をフックの前に算出していたため、フックが `skill` だけを書き換えると差し替え前の `base` と組み合わされ、基本技能と通常技能の境界をまたぐ差し替えで技能値が拾えなくなっていた。`base` は `skill` から一意に決まるので `config` から外し、フックの後に引き直している。実機検証に1件足し、直す前のコードで赤くなることを確認済み。

CSSは等値で置換できるものだけをトークンにした。ただし本体は `@media (max-width: 480px)` でフォントスケールを圧縮するので、**狭幅での見た目は変わる**（追従するほうが望ましいので入れている）。

CIのBiomeが 2.5.4 のまま残っていたので 2.5.5 に揃えた。3箇所を手で揃える手順が2連続で漏れているので、機械で検査する仕組みは別Issueにする。

ドキュメントの記述5件が現状とずれていたので実測値に直した。特に `code-design.md` の「`tools/` の checkJs に実在する取りこぼしが混じっている」は誤りだったので撤回している。27件を1件ずつ当たって、実行時に壊れるものは0件だった。

## 確認

typecheck / vitest 115件 / lint / build / docs:build / lang・templates・schema-doc、`npm run verify:live` 24件すべて通過。