### PR TITLE
効果まわりのv14追随と状態異常の登録

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -338,6 +338,16 @@
       "Inactive": "Inactive",
       "Toggle": "Toggle"
     },
+    "Status": {
+      "unconscious": "Unconscious",
+      "cardiacArrest": "Cardiac Arrest",
+      "dead": "Dead",
+      "faint": "Faint",
+      "possessed": "Possessed",
+      "deviation": "Deviation",
+      "blind": "Blind",
+      "invisible": "Invisible"
+    },
     "Import": {
       "DialogTitle": "Import Character Sheet",
       "ImportButton": "Import",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -339,6 +339,16 @@
       "Inactive": "無効",
       "Toggle": "切替"
     },
+    "Status": {
+      "unconscious": "気絶",
+      "cardiacArrest": "心肺停止",
+      "dead": "死亡",
+      "faint": "失神",
+      "possessed": "憑依",
+      "deviation": "逸脱",
+      "blind": "盲目",
+      "invisible": "不可視"
+    },
     "Import": {
       "DialogTitle": "キャラクターシートインポート",
       "ImportButton": "インポート",

--- a/module/config/status-effects.ts
+++ b/module/config/status-effects.ts
@@ -1,0 +1,79 @@
+/**
+ * トークンに付けられる状態。`CONFIG.statusEffects` に流し込む。
+ *
+ * 他の表と違って `label` ではなく `name` を持つのは、本体の StatusEffectConfig が
+ * そのキー名で読むため。翻訳は `ActiveEffect.fromStatusEffect` が
+ * `_loc(effectData.name)` で解決するので、preLocalize の対象にはしない。
+ *
+ * `showIcon` は指定しない。本体が `fromStatusEffect` で `??= ALWAYS` を入れており
+ * （v14 で `isTemporary` の判定から `statuses` が外れたぶんの手当て）、
+ * 期限を持たない状態でもトークンにアイコンが出る。
+ */
+export interface StatusEffectConfig {
+  name: string;
+  img: string;
+  /**
+   * トークンHUDでの並び順。
+   *
+   * 指定しないと本体が `order ?? 0` で揃えたうえで表示名の localeCompare に倒すので、
+   * ルール上の進行（気絶→心肺停止→死亡）が五十音順に崩れる。
+   */
+  order: number;
+}
+
+const definitions = {
+  // HPが尽きる側の3つ。ルール上は 気絶 → 心肺停止 → 死亡 の順に進む
+  unconscious: {
+    name: "EMOKLORE.Status.unconscious",
+    img: "icons/svg/unconscious.svg",
+    order: 1,
+  },
+  cardiacArrest: {
+    name: "EMOKLORE.Status.cardiacArrest",
+    img: "icons/svg/blood.svg",
+    order: 2,
+  },
+  dead: {
+    name: "EMOKLORE.Status.dead",
+    img: "icons/svg/skull.svg",
+    order: 3,
+  },
+
+  // MPが尽きたとき
+  faint: {
+    name: "EMOKLORE.Status.faint",
+    img: "icons/svg/daze.svg",
+    order: 4,
+  },
+
+  // 《怪異》に持っていかれる側の2つ
+  possessed: {
+    name: "EMOKLORE.Status.possessed",
+    img: "icons/svg/terror.svg",
+    order: 5,
+  },
+  deviation: {
+    name: "EMOKLORE.Status.deviation",
+    img: "icons/svg/cowled.svg",
+    order: 6,
+  },
+
+  // ここから下はルールブックに規定が無い。本体の視界・探知が
+  // CONFIG.specialStatusEffects 経由でこの2つを見ているので、
+  // エモクロアの状態に置き換えるときも落とさずに残す
+  blind: {
+    name: "EMOKLORE.Status.blind",
+    img: "icons/svg/blind.svg",
+    order: 7,
+  },
+  invisible: {
+    name: "EMOKLORE.Status.invisible",
+    img: "icons/svg/invisible.svg",
+    order: 8,
+  },
+} satisfies Record<string, StatusEffectConfig>;
+
+export type StatusEffectKey = keyof typeof definitions;
+
+// satisfies だけだと各値が個別の狭い型に推論されるため、値の型は StatusEffectConfig に揃える
+export const statusEffects: Record<StatusEffectKey, StatusEffectConfig> = definitions;

--- a/module/emoklore.ts
+++ b/module/emoklore.ts
@@ -4,6 +4,7 @@ import "../css/emoklore.css";
 import * as applications from "./applications/character-sheet";
 import { EmokloreWeaponSheet } from "./applications/weapon-sheet";
 import { EMOKLORE } from "./config/index";
+import { statusEffects } from "./config/status-effects";
 import { CharacterDataModel } from "./data/character";
 import { WeaponDataModel } from "./data/item-models";
 import { WeaponCardModel } from "./data/messages/weapon-card";
@@ -14,6 +15,7 @@ import { EmokloreItem } from "./documents/item";
 import { registerQueries } from "./documents/queries";
 import { getSetting, registerSystemSettings } from "./settings";
 import { performPreLocalization } from "./utils/localization";
+import { typedEntries } from "./utils/object";
 
 Hooks.once("init", () => {
   console.log("Emo-klore TRPG | Initializing...");
@@ -48,6 +50,23 @@ Hooks.once("init", () => {
 
   CONFIG.Dice.rolls.push(EmokloreRoll);
   CONFIG.Dice.terms.d = EmokloreDie;
+
+  // トークンに付けられる状態をエモクロアのものに差し替える。既定はD&D風の
+  // dead/blind/prone… で、ルールブックの【気絶】【心肺停止】などが1つも無い。
+  //
+  // 配列ごと代入せず1件ずつ出し入れするのは、v14の CONFIG.statusEffects が
+  // 添字とidの両方で引けるProxyだから。代入すると素の配列に戻り、本体が使う
+  // CONFIG.statusEffects[statusId] の形（fromStatusEffect など）が通らなくなる。
+  // idでの読み書きはProxyのtrapが配列側にも反映してくれるので、これで両立する
+  for (const id of Object.keys(CONFIG.statusEffects)) delete CONFIG.statusEffects[id];
+  for (const [id, config] of typedEntries(statusEffects)) {
+    CONFIG.statusEffects[id] = { id, ...config };
+  }
+
+  // 「撃破」として扱う状態。既定値も "dead" だが、キー名がたまたま一致している
+  // ことに頼らず明示する。残りの specialStatusEffects（invisible / blind /
+  // burrow / hover / fly）は本体の視界・探知が使うので既定のままにする
+  CONFIG.specialStatusEffects.DEFEATED = "dead";
 
   // トークンのリソースバーに出せる属性
   CONFIG.Actor.trackableAttributes = {

--- a/module/utils/effects.ts
+++ b/module/utils/effects.ts
@@ -22,7 +22,12 @@ export function prepareActiveEffectCategories(
     },
   };
 
-  // 無効なものを優先し、残りを一時的／恒常に振り分ける
+  // 無効なものを優先し、残りを一時的／恒常に振り分ける。
+  //
+  // v14 で `isSuppressed` が `duration.expired` を拾うようになり、期限切れの効果は
+  // `active` が落ちる。ただしここが見ているのは `disabled`（利用者が切ったか）なので、
+  // 期限切れは「無効」ではなく一時的／恒常のどちらかに残る。区分は
+  // 「利用者が切ったか」であって「いま効いているか」ではない
   for (const e of effects as Iterable<SheetActiveEffect>) {
     if (e.disabled) categories.inactive.effects.push(e);
     else if (e.isTemporary) categories.temporary.effects.push(e);

--- a/templates/actor/effects.hbs
+++ b/templates/actor/effects.hbs
@@ -18,7 +18,10 @@
               {{#if (eq section.type "inactive")}}
                 data-disabled="true"
               {{else if (eq section.type "temporary")}}
-                data-duration.rounds="1"
+                {{! v14 の duration は {value, units} 。rounds/turns/seconds の直指定は
+                    スキーマから消えており、data-duration.rounds では何も入らなかった }}
+                data-duration.value="1"
+                data-duration.units="rounds"
               {{/if}}
               data-tooltip='{{localize "DOCUMENT.Create" type=""}}'
             >

--- a/tests/live/checks/active-effect.mjs
+++ b/tests/live/checks/active-effect.mjs
@@ -1,0 +1,119 @@
+// 効果。状態異常の登録と、効果タブから作られる効果の中身を見る。
+//
+// どちらもv14で形が変わったところ。statusEffects は本体既定を丸ごと置き換えており、
+// duration は {value, units} になって rounds/turns の直指定がスキーマから消えた。
+import { TAG } from "../lib/config.mjs";
+import { assertInPage } from "../lib/harness.mjs";
+
+export const title = "効果";
+
+export async function run({ page, check }) {
+  await check("状態異常がエモクロアのものに置き換わっている", () =>
+    assertInPage(page, () => {
+      const expected = [
+        "unconscious",
+        "cardiacArrest",
+        "dead",
+        "faint",
+        "possessed",
+        "deviation",
+        "blind",
+        "invisible",
+      ];
+      // Proxy は id でも添字でも引ける。両方を確かめる
+      const byIndex = Array.from(foundry.utils.iterateValues(CONFIG.statusEffects)).map(
+        (s) => s.id,
+      );
+      const missing = expected.filter((id) => !CONFIG.statusEffects[id]);
+      const extra = byIndex.filter((id) => !expected.includes(id));
+      // name は i18n キーのまま持ち、本体が読むときに解決する。未解決のまま出ないか
+      const unresolved = expected.filter((id) => {
+        const name = CONFIG.statusEffects[id]?.name;
+        return !name || game.i18n.localize(name) === name;
+      });
+
+      const problems = [];
+      if (missing.length > 0) problems.push(`不足[${missing.join(",")}]`);
+      if (extra.length > 0) problems.push(`余分[${extra.join(",")}]`);
+      if (unresolved.length > 0) problems.push(`未翻訳[${unresolved.join(",")}]`);
+      // 並び順は order で決まる。指定が無いと表示名の localeCompare に倒れる
+      if (byIndex.join() !== expected.join()) problems.push(`順序=${byIndex.join(",")}`);
+
+      return {
+        ok: problems.length === 0,
+        detail:
+          problems.length === 0
+            ? `${expected.length}件（${expected.map((id) => game.i18n.localize(CONFIG.statusEffects[id].name)).join("・")}）`
+            : problems.join(" / "),
+      };
+    }),
+  );
+
+  await check("specialStatusEffects の参照先が実在する", () =>
+    assertInPage(page, () => {
+      // DEFEATED は明示的に "dead" へ向けている。残りは本体既定のままなので、
+      // 置き換えで参照先が消えたものは「使わない」ことがはっきりしていればよい
+      const defeated = CONFIG.specialStatusEffects.DEFEATED;
+      const ok = !!CONFIG.statusEffects[defeated];
+      const dangling = Object.entries(CONFIG.specialStatusEffects)
+        .filter(([, id]) => !CONFIG.statusEffects[id])
+        .map(([key]) => key);
+      return {
+        ok,
+        detail: ok
+          ? `DEFEATED=${defeated}${dangling.length > 0 ? `（未使用: ${dangling.join(",")}）` : ""}`
+          : `DEFEATED=${defeated} が statusEffects に無い`,
+      };
+    }),
+  );
+
+  await check("状態異常が付け外しできる", () =>
+    assertInPage(
+      page,
+      async (tag) => {
+        const a = game.actors.getName(`${tag}_char`);
+        await a.toggleStatusEffect("unconscious");
+        const on = a.statuses.has("unconscious");
+        await a.toggleStatusEffect("unconscious");
+        const off = !a.statuses.has("unconscious");
+        return {
+          ok: on && off,
+          detail: on && off ? "付与→解除まで往復した" : `付与=${on} 解除=${off}`,
+        };
+      },
+      TAG,
+    ),
+  );
+
+  await check("一時的効果の作成が duration を持つ", () =>
+    assertInPage(
+      page,
+      async (tag) => {
+        const a = game.actors.getName(`${tag}_char`);
+        const el = a.sheet.element.querySelector(
+          "[data-effect-type=temporary] [data-action=createDoc][data-document-class=ActiveEffect]",
+        );
+        if (!el) return { ok: false, detail: "一時的効果の作成ボタンが無い" };
+
+        const before = a.effects.size;
+        el.click();
+        await window.__waitFor(() => a.effects.size > before, {
+          soft: true,
+          label: "一時的効果の作成",
+        });
+        const effect = a.effects.contents.at(-1);
+        // v14 のスキーマは {value, units}。data-duration.rounds を渡していたころは
+        // どこにも入らず、作った効果が「恒常」の側に並んでいた
+        const { value, units } = effect?.duration ?? {};
+        const ok = value === 1 && units === "rounds" && effect?.isTemporary === true;
+        const detail = ok
+          ? `value=${value} units=${units} isTemporary=true`
+          : `value=${value} units=${units} isTemporary=${effect?.isTemporary}`;
+
+        await effect?.delete();
+        return { ok, detail };
+      },
+      TAG,
+    ),
+  );
+}

--- a/tests/live/run.mjs
+++ b/tests/live/run.mjs
@@ -11,6 +11,7 @@
 //
 // 検証を足すときは checks/ にファイルを1つ作って CHECKS に並べる。
 
+import * as activeEffect from "./checks/active-effect.mjs";
 import * as characterSheet from "./checks/character-sheet.mjs";
 import * as consoleCheck from "./checks/console.mjs";
 import * as importCheck from "./checks/import.mjs";
@@ -26,7 +27,16 @@ import { createRunner, DICE, installPageHelpers, pinDice } from "./lib/harness.m
 
 // 並び順に意味がある。土台（登録・スキーマ）から先に見て、
 // 総合（エラーの有無）は全部触ったあとで見る
-const CHECKS = [registration, schema, characterSheet, skillRoll, weapon, importCheck, consoleCheck];
+const CHECKS = [
+  registration,
+  schema,
+  characterSheet,
+  skillRoll,
+  weapon,
+  activeEffect,
+  importCheck,
+  consoleCheck,
+];
 
 const log = (msg) => console.log(msg);
 


### PR DESCRIPTION
ActiveEffect本格導入の1本目。土台の3点を直す。

## 一時的効果が作れていなかった

効果タブの「一時的効果」の＋ボタンが、期限を持たない恒常の効果を作っていた。押した先から「永続的効果」の区分に並ぶので、一時的効果を作る手段が無かった。

v14のdurationは `{value, units}` で、`rounds` / `turns` / `seconds` の直指定はスキーマから消えている。本体には `duration.rounds` を読み替える移行シムがあるが、発火条件が `typeof duration[unit] === "number"` で、datasetから来る値は文字列なので通らない。旧テンプレートのまま実機で走らせ `value=Infinity units=seconds isTemporary=false` になることを確認した。

## 状態異常を登録した

`CONFIG.statusEffects` は本体既定のままで、D&D風の dead/blind/prone… という一式だった。ルールブックが規定する【気絶】【心肺停止】【死亡】【失神】【憑依】【逸脱】に置き換える。

`blind` / `invisible` だけは本体のものを残した。ルールブックに規定は無いが、視界・探知が `CONFIG.specialStatusEffects` 経由でこの2つを見ており、落とすと本体側の機能が黙って効かなくなる。

配列ごと代入せず1件ずつ入れ替えているのは、v14の `CONFIG.statusEffects` が添字とidの両方で引けるProxyになったため。代入すると素の配列に戻り、本体が使う `CONFIG.statusEffects[statusId]` の形が通らなくなる。

## 実機検証を24件→28件に

状態異常の登録もdurationの形も、起動しないと確かめようがない。「一時的効果の作成が duration を持つ」は上の修正の回帰テストになっている。