### PR TITLE
全体修正の追加と、保存しない値の整理

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -29,13 +29,21 @@ ActiveEffectでどのキーを変更できるかは [効果（ActiveEffect）](/
 | パス | 型 | 既定 | 意味 |
 |---|---|---|---|
 | `resources.hp.value` | NumberField | 11 | 現在HP |
-| `resources.hp.max` | NumberField | 11 | 最大HP。**毎回上書きされる**（下の導出値を参照） |
+| `resources.hp.max` | NumberField | 11 | 最大HP。**保存しない**（下の導出値を参照） |
 | `resources.mp.value` | NumberField | 2 | 現在MP |
-| `resources.mp.max` | NumberField | 2 | 最大MP。**毎回上書きされる** |
+| `resources.mp.max` | NumberField | 2 | 最大MP。**保存しない** |
 | `resources.resonance.value` | NumberField | 1 | 共鳴値。1未満にはならない |
 | `resources.resonance.max` | NumberField | 9 | 共鳴値の上限。こちらは計算しないので手で決める |
 
-`hp.max` と `mp.max` はスキーマ上は書き込めるが、`prepareDerivedData` が能力値から計算し直すので書いた値は残らない。取り込みも書いているが、同じ理由で効いていない。
+`hp.max` と `mp.max` は `persisted: false` を付けてある。`prepareDerivedData` が能力値から計算し直すので、書いても次の準備で捨てられる値だった。スキーマには残っているので[効果](/active-effect)の適用先にはでき、`phase: "final"` なら上書きが残る。
+
+**保存しないだけで、読むぶんには普通のフィールド**。シートもトークンバーも `system.resources.hp.max` をそのまま読む。
+
+### `system.mod`
+
+判定すべてに効く修正。`mod` の3つ（`bonus` / `success` / `target`）だけを持ち、シートには出ない。
+
+ルールブックの極限共鳴（ハウリング）には「全ての技能は判定値-2される」のように、能力値でも技能でも技能グループでも切り分けられない修正が繰り返し出てくる。それを受ける場所がこれ。他の `mod` と同じく `persisted: false`。
 
 ### `system.characteristics.<能力値>`
 
@@ -46,7 +54,9 @@ ActiveEffectでどのキーを変更できるかは [効果（ActiveEffect）](/
 | `characteristics.<k>.mod.success` | NumberField | 既定0 | 成功数への修正 |
 | `characteristics.<k>.mod.target` | NumberField | 既定0 | 目標値への修正 |
 
-`mod` の3つはシートから編集できない。ActiveEffectの適用先として存在している。この組は能力値・技能・基本技能・技能グループの4箇所に出てくるので `modifierField()` にまとめてある。
+`mod` の3つはシートから編集できない。ActiveEffectの適用先として存在している。この組は全体・能力値・技能・基本技能・技能グループの5箇所に出てくるので `modifierField()` にまとめてある。
+
+**`mod` は保存しない**（`persisted: false`）。効果の着地点としてしか使わないので、保存すると全部0のフィールドがアクター1体につき64組×3値ぶん並ぶだけになる。スキーマには残るので効果は本来の経路で乗り、効果値のRoll評価も整数の検証も効く。
 
 キーは8種:
 
@@ -189,7 +199,9 @@ ActiveEffectでどのキーを変更できるかは [効果（ActiveEffect）](/
 
 `hp.value` / `mp.value` は `max` を超えないよう毎回丸める。
 
-**`initiative` だけはスキーマにフィールドが無い。** `declare` で型に足しているだけだが、`system.json` の `"initiative": "@initiative"` から参照されるので、消すとイニシアチブが振れなくなる。
+導出値のうち `resources.hp.max` / `resources.mp.max` / `initiative` は**スキーマにフィールドがあり、保存だけしない**（`persisted: false`）。かつて `initiative` はスキーマに無く `declare` だけで足していたが、それだと効果を当てたとき本体が値の型を推測する経路に落ち、効果値のRoll評価も整数の検証も効かなかった。
+
+`skills.<k>.target` と `baseSkills.<k>.target` はいまもスキーマに無く `declare` だけ。効果を当てること自体はできるが、上の3つと違って検証を伴わない。
 
 ## Item `weapon`
 

--- a/module/data/character.ts
+++ b/module/data/character.ts
@@ -63,11 +63,17 @@ export type SkillRollContext = {
  * コピーされていたので、対応が1対1になるようここへ寄せた。
  */
 const modifierField = () =>
-  new SchemaField({
-    bonus: new NumberField({ required: true, integer: true, initial: 0 }),
-    success: new NumberField({ required: true, integer: true, initial: 0 }),
-    target: new NumberField({ required: true, integer: true, initial: 0 }),
-  });
+  new SchemaField(
+    {
+      bonus: new NumberField({ required: true, integer: true, initial: 0 }),
+      success: new NumberField({ required: true, integer: true, initial: 0 }),
+      target: new NumberField({ required: true, integer: true, initial: 0 }),
+    },
+    // 保存しない。この組はシートから編集できず、ActiveEffectの着地点としてだけ存在する。
+    // スキーマには残るので効果は DataField 経由で乗り、効果値のRoll評価も整数の検証も効く。
+    // 保存対象から外れることで、アクター1体につき 64組×3値 が保存データから消える
+    { persisted: false },
+  );
 
 // 能力値の NumberField に渡す共通オプション。技能側で分割代入する
 // characteristic（能力値キーの文字列）とは別物なので名前を分けている
@@ -80,21 +86,46 @@ const characteristicFieldOptions = {
   nullable: false,
 };
 
+// HP・MPの最大値は毎回 prepareDerivedData が能力値から出し直すので保存しない。
+// 保存しても次の準備で捨てられる値で、スキーマに居座ると「書けるのに残らない」
+// フィールドになる。効果を当てたいときは phase: "final" で上書きする
+const derivedMaxField = (initial: number) =>
+  new NumberField({ required: true, integer: true, initial, persisted: false });
+
 const defineCharacterDataModelSchema = () => ({
   resources: new SchemaField({
     hp: new SchemaField({
       value: new NumberField({ required: true, integer: true, initial: 11 }),
-      max: new NumberField({ required: true, integer: true, initial: 11 }),
+      max: derivedMaxField(11),
     }),
     mp: new SchemaField({
       value: new NumberField({ required: true, integer: true, initial: 2 }),
-      max: new NumberField({ required: true, integer: true, initial: 2 }),
+      max: derivedMaxField(2),
     }),
     resonance: new SchemaField({
       value: new NumberField({ required: true, integer: true, initial: 1 }),
+      // 共鳴値の上限だけは計算せず手で決めるので、こちらは保存する
       max: new NumberField({ required: true, integer: true, initial: 9 }),
     }),
   }),
+
+  /**
+   * 判定すべてに効く修正。
+   *
+   * ルールブックの「全ての技能は判定値-2される」のように、能力値でも技能でも
+   * 技能グループでも切り分けられない修正がハウリング表に多くあり、これまで
+   * 表現する場所が無かった。他の mod と同じ3値を持つ
+   */
+  mod: modifierField(),
+
+  /**
+   * 行動値。身体＋〈スピード〉のレベルで、prepareDerivedData が毎回入れ直す。
+   *
+   * 保存しないがスキーマには置く。`system.json` の `"initiative": "@initiative"` が
+   * 参照するうえ、ここに無いとActiveEffectを当てたとき本体が型を推測する経路に落ちて、
+   * 効果値のRoll評価も整数の検証も効かなくなる
+   */
+  initiative: new NumberField({ required: true, integer: true, initial: 0, persisted: false }),
 
   characteristics: new SchemaField(
     Object.fromEntries(
@@ -252,6 +283,12 @@ export class CharacterDataModel extends EmokloreSystemDataModel {
     }
   >;
 
+  /** 判定すべてに効く修正 */
+  declare mod: ModifierSet;
+
+  /** 行動値。prepareDerivedData が毎回入れ直す */
+  declare initiative: number;
+
   declare emotions: {
     surface?: string;
     hidden?: string;
@@ -270,8 +307,6 @@ export class CharacterDataModel extends EmokloreSystemDataModel {
     likesAndDislikes?: string;
     note: string;
   };
-
-  declare initiative: number;
 
   static override defineSchema() {
     return defineCharacterDataModelSchema();
@@ -364,10 +399,7 @@ export class CharacterDataModel extends EmokloreSystemDataModel {
       skillMod: entry.mod,
       characteristicMod: this.characteristics[entry.characteristic].mod,
       skillGroupMod: this.skillGroups[group].mod,
+      globalMod: this.mod,
     };
-  }
-
-  modifyRollData(rollData: Record<string, unknown>): void {
-    rollData.initiative = this.initiative;
   }
 }

--- a/module/documents/actor.ts
+++ b/module/documents/actor.ts
@@ -32,12 +32,18 @@ export class EmokloreActor extends Actor {
   declare items: foundry.utils.Collection<string, EmokloreItem>;
   declare effects: foundry.utils.Collection<string, foundry.documents.ActiveEffect>;
 
+  /**
+   * `@` で参照できる値。判定式のほか、ActiveEffectの効果値の解決にも使われる
+   * （本体の `applyActiveEffects` が `replacementData` としてこれを渡す）。
+   *
+   * `system` を展開するだけでスキーマのフィールドは一通り入る。以前は
+   * `initiative` がスキーマに無く `modifyRollData` で足していたが、
+   * 実フィールドになったので中継が要らなくなった。
+   *
+   * 展開は浅いので、入れ子は参照のまま。効果の適用途中でも現在値が読める
+   */
   override getRollData(): Record<string, unknown> {
-    const rollData = { ...this.system, flags: this.flags, name: this.name };
-
-    this.system.modifyRollData(rollData);
-
-    return rollData;
+    return { ...this.system, flags: this.flags, name: this.name };
   }
 
   /**

--- a/module/rules/skill-roll.test.ts
+++ b/module/rules/skill-roll.test.ts
@@ -1,69 +1,96 @@
 import { describe, expect, it } from "vitest";
-import { formatDMPart, resolveSkillRoll } from "./skill-roll";
+import { formatDMPart, resolveSkillRoll, type SkillRollParams } from "./skill-roll";
 import type { ModifierSet } from "./types";
 
 const noMod: ModifierSet = { bonus: 0, success: 0, target: 0 };
 const mod = (m: Partial<ModifierSet>): ModifierSet => ({ ...noMod, ...m });
 
+/**
+ * 修正の系統は4つあるが、1件のテストが見たいのはたいてい1〜2系統だけ。
+ * 残りを既定で埋めて、注目している修正だけがテストの本文に出るようにする。
+ */
+const params = (
+  p: Partial<SkillRollParams> & Pick<SkillRollParams, "level" | "baseTarget">,
+): SkillRollParams => ({
+  skillMod: noMod,
+  characteristicMod: noMod,
+  skillGroupMod: noMod,
+  globalMod: noMod,
+  ...p,
+});
+
 describe("resolveSkillRoll", () => {
   it("修正がなければレベルがダイス数、基準値が目標値になる", () => {
-    expect(
-      resolveSkillRoll({
+    expect(resolveSkillRoll(params({ level: 2, baseTarget: 6 }))).toEqual({
+      diceCount: 2,
+      target: 6,
+      successMod: 0,
+      dmFormula: "2DM≦6",
+    });
+  });
+
+  it("4系統のボーナスがダイス数に合算される", () => {
+    const spec = resolveSkillRoll(
+      params({
         level: 2,
         baseTarget: 6,
-        skillMod: noMod,
-        characteristicMod: noMod,
-        skillGroupMod: noMod,
+        skillMod: mod({ bonus: 1 }),
+        characteristicMod: mod({ bonus: 2 }),
+        skillGroupMod: mod({ bonus: 3 }),
+        globalMod: mod({ bonus: 1 }),
       }),
-    ).toEqual({ diceCount: 2, target: 6, successMod: 0, dmFormula: "2DM≦6" });
+    );
+
+    expect(spec.diceCount).toBe(9);
+    expect(spec.dmFormula).toBe("(2+7)DM≦6");
   });
 
-  it("3系統のボーナスがダイス数に合算される", () => {
-    const spec = resolveSkillRoll({
-      level: 2,
-      baseTarget: 6,
-      skillMod: mod({ bonus: 1 }),
-      characteristicMod: mod({ bonus: 2 }),
-      skillGroupMod: mod({ bonus: 3 }),
-    });
+  it("4系統の目標値修正が目標値に合算される", () => {
+    const spec = resolveSkillRoll(
+      params({
+        level: 2,
+        baseTarget: 6,
+        skillMod: mod({ target: 1 }),
+        characteristicMod: mod({ target: -2 }),
+        skillGroupMod: mod({ target: 1 }),
+        globalMod: mod({ target: 1 }),
+      }),
+    );
 
-    expect(spec.diceCount).toBe(8);
-    expect(spec.dmFormula).toBe("(2+6)DM≦6");
+    expect(spec.target).toBe(7);
+    expect(spec.dmFormula).toBe("2DM≦(6+1)");
   });
 
-  it("3系統の目標値修正が目標値に合算される", () => {
-    const spec = resolveSkillRoll({
-      level: 2,
-      baseTarget: 6,
-      skillMod: mod({ target: 1 }),
-      characteristicMod: mod({ target: -2 }),
-      skillGroupMod: mod({ target: 1 }),
-    });
+  it("4系統の成功数修正が合算される", () => {
+    const spec = resolveSkillRoll(
+      params({
+        level: 1,
+        baseTarget: 4,
+        skillMod: mod({ success: 1 }),
+        characteristicMod: mod({ success: 1 }),
+        skillGroupMod: mod({ success: -1 }),
+        globalMod: mod({ success: -1 }),
+      }),
+    );
 
-    expect(spec.target).toBe(6);
-    expect(spec.dmFormula).toBe("2DM≦6");
+    expect(spec.successMod).toBe(0);
   });
 
-  it("3系統の成功数修正が合算される", () => {
-    const spec = resolveSkillRoll({
-      level: 1,
-      baseTarget: 4,
-      skillMod: mod({ success: 1 }),
-      characteristicMod: mod({ success: 1 }),
-      skillGroupMod: mod({ success: -1 }),
-    });
+  // 「全ての技能は判定値-2される」。技能でも能力値でも技能グループでも
+  // 切り分けられないので、全体修正だけが受け取れる
+  it("全体修正だけでも判定に効く", () => {
+    const spec = resolveSkillRoll(
+      params({ level: 2, baseTarget: 6, globalMod: mod({ target: -2 }) }),
+    );
 
-    expect(spec.successMod).toBe(1);
+    expect(spec.target).toBe(4);
+    expect(spec.dmFormula).toBe("2DM≦(6-2)");
   });
 
   it("負の修正は括弧付きでそのまま式に出る", () => {
-    const spec = resolveSkillRoll({
-      level: 3,
-      baseTarget: 5,
-      skillMod: mod({ bonus: -1, target: -2 }),
-      characteristicMod: noMod,
-      skillGroupMod: noMod,
-    });
+    const spec = resolveSkillRoll(
+      params({ level: 3, baseTarget: 5, skillMod: mod({ bonus: -1, target: -2 }) }),
+    );
 
     expect(spec).toEqual({
       diceCount: 2,

--- a/module/rules/skill-roll.ts
+++ b/module/rules/skill-roll.ts
@@ -8,12 +8,14 @@ export type SkillRollParams = {
   skillMod: ModifierSet;
   characteristicMod: ModifierSet;
   skillGroupMod: ModifierSet;
+  /** 判定すべてに効く修正。「全ての技能は判定値-2される」のような、範囲で切れないもの */
+  globalMod: ModifierSet;
 };
 
 /**
  * 技能判定の内容を決める。
  *
- * 技能・能力値・技能グループの3系統の修正値を合算し、
+ * 技能・能力値・技能グループ・全体の4系統の修正値を合算し、
  * ダイス数（レベル+ボーナス）と目標値（基準値+目標値修正）を出す。
  */
 export function resolveSkillRoll({
@@ -22,10 +24,15 @@ export function resolveSkillRoll({
   skillMod,
   characteristicMod,
   skillGroupMod,
+  globalMod,
 }: SkillRollParams): RollSpec {
-  const bonus = skillMod.bonus + characteristicMod.bonus + skillGroupMod.bonus;
-  const targetMod = skillMod.target + characteristicMod.target + skillGroupMod.target;
-  const successMod = skillMod.success + characteristicMod.success + skillGroupMod.success;
+  const mods = [skillMod, characteristicMod, skillGroupMod, globalMod];
+  const sum = (pick: (mod: ModifierSet) => number) =>
+    mods.reduce((total, mod) => total + pick(mod), 0);
+
+  const bonus = sum((mod) => mod.bonus);
+  const targetMod = sum((mod) => mod.target);
+  const successMod = sum((mod) => mod.success);
 
   return {
     diceCount: level + bonus,

--- a/module/utils/charsheet-importer.ts
+++ b/module/utils/charsheet-importer.ts
@@ -214,12 +214,13 @@ export async function importFromCharSheet(
         typeof status.value === "string" ? Number.parseInt(status.value, 10) : status.value;
       const max = typeof status.max === "string" ? Number.parseInt(status.max, 10) : status.max;
 
+      // HP・MPの最大値は取り込まない。能力値から prepareDerivedData が出し直すので、
+      // 書いても保存されない（スキーマ側が persisted: false）。取り込み元の最大値と
+      // 食い違うなら、原因は能力値のほうにある
       if (label === "HP") {
         updateData["system.resources.hp.value"] = value;
-        updateData["system.resources.hp.max"] = max;
       } else if (label === "MP") {
         updateData["system.resources.mp.value"] = value;
-        updateData["system.resources.mp.max"] = max;
       } else if (label === "共鳴") {
         updateData["system.resources.resonance.value"] = value;
         updateData["system.resources.resonance.max"] = max;

--- a/tests/live/checks/active-effect.mjs
+++ b/tests/live/checks/active-effect.mjs
@@ -85,6 +85,169 @@ export async function run({ page, check }) {
     ),
   );
 
+  await check("全体修正が判定に効く", () =>
+    assertInPage(
+      page,
+      async (tag) => {
+        const a = game.actors.getName(`${tag}_char`);
+        const el = a.sheet.element.querySelector("[data-roll-type=skill][data-skill=search]");
+        if (!el) return { ok: false, detail: "〈検索〉の判定ボタンが無い" };
+
+        // 目標値もダイス数も他の検証で動くので、絶対値ではなく前後の差で見る
+        const rollOnce = async () => {
+          const before = game.messages.size;
+          el.click();
+          await window.__waitFor(() => game.messages.size > before, {
+            soft: true,
+            label: "技能判定",
+          });
+          return game.messages.contents.at(-1)?.rolls?.[0]?.formula ?? "";
+        };
+        const parse = (formula) => {
+          const m = /^(\d+)d10em<=(-?\d+)/.exec(formula);
+          return m ? { dice: Number(m[1]), target: Number(m[2]) } : null;
+        };
+
+        const baseline = await rollOnce();
+        const [effect] = await a.createEmbeddedDocuments("ActiveEffect", [
+          {
+            name: `${tag}_global`,
+            system: {
+              changes: [
+                { key: "system.mod.target", type: "add", value: -2, phase: "initial" },
+                { key: "system.mod.bonus", type: "add", value: 1, phase: "initial" },
+              ],
+            },
+          },
+        ]);
+        const modified = await rollOnce();
+        await effect.delete();
+
+        const b = parse(baseline);
+        const m = parse(modified);
+        const ok = !!b && !!m && m.dice === b.dice + 1 && m.target === b.target - 2;
+        return {
+          ok,
+          detail: ok ? `${baseline} → ${modified}` : `前=${baseline} 後=${modified}`,
+        };
+      },
+      TAG,
+    ),
+  );
+
+  await check("修正値は保存されないが効果は乗る", () =>
+    assertInPage(
+      page,
+      async (tag) => {
+        const a = game.actors.getName(`${tag}_char`);
+        // persisted: false なので _source には出ない。スキーマには在るので効果は乗る
+        const source = a._source.system;
+        const stored = [
+          source.mod !== undefined && "mod",
+          source.characteristics?.physical?.mod !== undefined && "characteristics.physical.mod",
+          source.skills?.search?.mod !== undefined && "skills.search.mod",
+          source.initiative !== undefined && "initiative",
+          source.resources?.hp?.max !== undefined && "resources.hp.max",
+        ].filter(Boolean);
+
+        const [effect] = await a.createEmbeddedDocuments("ActiveEffect", [
+          {
+            name: `${tag}_persist`,
+            system: {
+              changes: [{ key: "system.mod.target", type: "add", value: -2, phase: "initial" }],
+            },
+          },
+        ]);
+        const applied = a.system.mod.target;
+        await effect.delete();
+        const cleared = a.system.mod.target;
+
+        const ok = stored.length === 0 && applied === -2 && cleared === 0;
+        return {
+          ok,
+          detail: ok
+            ? "保存データに mod / initiative / hp.max なし、効果は -2 → 0 で往復"
+            : `保存された[${stored.join(",")}] 適用=${applied} 解除後=${cleared}`,
+        };
+      },
+      TAG,
+    ),
+  );
+
+  await check("派生値には final フェーズだけが効く", () =>
+    assertInPage(
+      page,
+      async (tag) => {
+        const a = game.actors.getName(`${tag}_char`);
+        const base = a.system.initiative;
+
+        const apply = async (phase) => {
+          const [effect] = await a.createEmbeddedDocuments("ActiveEffect", [
+            {
+              name: `${tag}_${phase}`,
+              system: { changes: [{ key: "system.initiative", type: "add", value: 2, phase }] },
+            },
+          ]);
+          const got = a.system.initiative;
+          await effect.delete();
+          return got;
+        };
+
+        // initial は prepareDerivedData が行動値を入れ直すぶん消える。final はその後に乗る
+        const afterInitial = await apply("initial");
+        const afterFinal = await apply("final");
+
+        const ok = afterInitial === base && afterFinal === base + 2;
+        return {
+          ok,
+          detail: ok
+            ? `行動値${base}: initial→${afterInitial}（消える） final→${afterFinal}`
+            : `base=${base} initial=${afterInitial} final=${afterFinal}`,
+        };
+      },
+      TAG,
+    ),
+  );
+
+  await check("効果値に @ 参照と式が書ける", () =>
+    assertInPage(
+      page,
+      async (tag) => {
+        const a = game.actors.getName(`${tag}_char`);
+        const level = a.system.skills.search.level;
+        if (!level) return { ok: false, detail: "〈検索〉のレベルが0で、0との区別が付かない" };
+
+        // 数値フィールドへの文字列は本体が Roll として評価する（NumberField._castChangeDelta）
+        const [effect] = await a.createEmbeddedDocuments("ActiveEffect", [
+          {
+            name: `${tag}_ref`,
+            system: {
+              changes: [
+                {
+                  key: "system.mod.bonus",
+                  type: "add",
+                  value: "@skills.search.level * 2",
+                  phase: "initial",
+                },
+              ],
+            },
+          },
+        ]);
+        const got = a.system.mod.bonus;
+        await effect.delete();
+
+        const ok = got === level * 2;
+        return {
+          ok,
+          detail: ok
+            ? `@skills.search.level * 2 → ${got}（レベル${level}）`
+            : `期待${level * 2} 実際${got}`,
+        };
+      },
+      TAG,
+    ),
+  );
+
   await check("一時的効果の作成が duration を持つ", () =>
     assertInPage(
       page,


### PR DESCRIPTION
ActiveEffect本格導入の2本目。#62 の上に積んでいる。

## 全体修正 `system.mod` を足した

ルールブックの極限共鳴（ハウリング）には「全ての技能は判定値-2される」のような、能力値でも技能でも技能グループでも切り分けられない修正が繰り返し出てくる。効果表のうち15件ほどがこれで、受ける場所が無かった。

他の `mod` と同じ3値を持たせ、`resolveSkillRoll` の合算に4系統目として足す。

## 保存する意味の無い値を保存しなくした

`mod` は「シートから編集できず、効果の着地点としてだけ存在する」もの。`hp.max` / `mp.max` / `initiative` は `prepareDerivedData` が毎回入れ直すもの。どちらも保存する理由が無いのに保存していたので、v14の `persisted: false` に寄せた。

**スキーマには残るので効果はこれまでどおり乗る。** 保存対象から消えるのは 64組×3値 と最大値2つ。既存データに残る分は次の保存時に本体が落とすので、移行の仕組みは要らない。

`initiative` はこれまでスキーマに無く `declare` だけで足していた。それだと効果を当てたとき本体が値の型を推測する経路に落ちて、効果値のRoll評価も整数の検証も効かない。実フィールドにした。あわせて、スキーマに入ったことで中継が空になった `modifyRollData` を外している。

取り込みが `hp.max` / `mp.max` に書いていたのも消した。もともと効いていなかった（`docs/data-model.md` にそう書いてある）が、これで確実に捨てられるようになった。

## 実機検証を28件→32件に

| 検証 | 結果 |
|---|---|
| 全体修正が判定に効く | `3d10em<=8` → `4d10em<=6` |
| 修正値は保存されないが効果は乗る | 保存データに `mod` / `initiative` / `hp.max` なし、効果は -2 → 0 で往復 |
| 派生値には final フェーズだけが効く | 行動値5: initial→5（消える） final→7 |
| 効果値に @ 参照と式が書ける | `@skills.search.level * 2` → 6 |

3件目がv14の2フェーズ適用の回帰テストになっている。4件目は、数値フィールドへの文字列changeを本体が Roll として評価する（`NumberField._castChangeDelta`）ことの確認で、`@` の解決を自前で書く必要が無いことの裏取りでもある。