### PR TITLE
属性キーを手打ちから選択式に

### DIFF
--- a/css/applications/active-effect-config.css
+++ b/css/applications/active-effect-config.css
@@ -1,0 +1,52 @@
+/* 効果の設定シート固有のレイアウト。変更行の列割りだけを持つ。
+   本体は キー／種別／効果値／優先度 の4列だが、こちらはキーを「対象／種類」に割り、
+   段階（initial / final）を足した6列になる */
+
+.emoklore.active-effect-config {
+  /* 6列ぶんを収めるので、本体の既定（560px）では狭い */
+  .em-effect-changes {
+    --em-effect-change-columns: minmax(0, 1.4fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr)
+      minmax(0, 0.9fr) minmax(0, 0.6fr) auto;
+  }
+
+  .em-effect-changes__head,
+  .em-effect-change {
+    display: grid;
+    grid-template-columns: var(--em-effect-change-columns);
+    align-items: center;
+    gap: var(--spacer-4);
+  }
+
+  .em-effect-changes__head {
+    padding-bottom: var(--spacer-4);
+    font-size: var(--font-size-12);
+    font-weight: bold;
+  }
+
+  .em-effect-changes__body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacer-4);
+    padding: 0;
+    list-style: none;
+  }
+
+  /* 選択肢の文字が長い（〈専門知識〉など）ので、列を押し広げないよう中で省略させる。
+     grid item の既定は min-width: auto なので minmax(0, …) だけでは足りない */
+  .em-effect-change select,
+  .em-effect-change input {
+    min-width: 0;
+    width: 100%;
+  }
+
+  /* 種類の選択と生入力は同じ場所に出し入れするので、片方だけが見えるよう重ねずに並べる。
+     hidden 属性で消えるほうは領域も持たない */
+  .em-effect-change__aspect {
+    display: grid;
+  }
+
+  .em-effect-change__controls {
+    display: flex;
+    justify-content: end;
+  }
+}

--- a/css/emoklore.css
+++ b/css/emoklore.css
@@ -23,6 +23,7 @@
 @import url("./applications/character-sheet.css");
 @import url("./applications/weapon-sheet.css");
 @import url("./applications/charsheet-import-dialog.css");
+@import url("./applications/active-effect-config.css");
 
 /* Chat — シートの外に出るチャットカード */
 @import url("./chat/dice-roll.css");

--- a/lang/en.json
+++ b/lang/en.json
@@ -347,7 +347,8 @@
         "skills": "Skills",
         "baseSkills": "Base Skills",
         "other": "Other",
-        "rawKey": "Enter a key directly"
+        "rawKey": "Enter a key directly",
+        "unselected": "Choose…"
       },
       "Aspect": {
         "Label": "Modifies",

--- a/lang/en.json
+++ b/lang/en.json
@@ -27,7 +27,8 @@
     "Sheet": {
       "class": {
         "character": "Character Sheet",
-        "weapon": "Weapon Sheet"
+        "weapon": "Weapon Sheet",
+        "activeEffect": "Effect Sheet"
       },
       "toggleMode": "Toggle Play/Edit mode",
       "character": {
@@ -336,7 +337,29 @@
       "Temporary": "Temporary",
       "Passive": "Passive",
       "Inactive": "Inactive",
-      "Toggle": "Toggle"
+      "Toggle": "Toggle",
+      "Target": "Target",
+      "TargetGroup": {
+        "global": "Global",
+        "everyRoll": "Every Roll",
+        "characteristics": "Characteristics",
+        "skillGroups": "Skill Groups",
+        "skills": "Skills",
+        "baseSkills": "Base Skills",
+        "other": "Other",
+        "rawKey": "Enter a key directly"
+      },
+      "Aspect": {
+        "Label": "Modifies",
+        "bonus": "Dice Bonus",
+        "target": "Target Number",
+        "success": "Successes"
+      },
+      "Phase": {
+        "Label": "Phase",
+        "initial": "Normal",
+        "final": "After Derivation"
+      }
     },
     "Status": {
       "unconscious": "Unconscious",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -27,7 +27,8 @@
     "Sheet": {
       "class": {
         "character": "キャラクターシート",
-        "weapon": "武器シート"
+        "weapon": "武器シート",
+        "activeEffect": "効果シート"
       },
       "toggleMode": "プレイ・編集モード切替",
       "character": {
@@ -337,7 +338,29 @@
       "Temporary": "一時的効果",
       "Passive": "永続的効果",
       "Inactive": "無効",
-      "Toggle": "切替"
+      "Toggle": "切替",
+      "Target": "対象",
+      "TargetGroup": {
+        "global": "全体",
+        "everyRoll": "すべての判定",
+        "characteristics": "能力値",
+        "skillGroups": "技能グループ",
+        "skills": "技能",
+        "baseSkills": "基本技能",
+        "other": "その他",
+        "rawKey": "キーを直接指定"
+      },
+      "Aspect": {
+        "Label": "修正先",
+        "bonus": "ダイスボーナス",
+        "target": "判定値",
+        "success": "成功数"
+      },
+      "Phase": {
+        "Label": "段階",
+        "initial": "通常",
+        "final": "計算後"
+      }
     },
     "Status": {
       "unconscious": "気絶",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -348,7 +348,8 @@
         "skills": "技能",
         "baseSkills": "基本技能",
         "other": "その他",
-        "rawKey": "キーを直接指定"
+        "rawKey": "キーを直接指定",
+        "unselected": "選んでください"
       },
       "Aspect": {
         "Label": "修正先",

--- a/module/applications/active-effect-config.ts
+++ b/module/applications/active-effect-config.ts
@@ -127,7 +127,11 @@ export class EmokloreActiveEffectConfig extends foundry.applications.sheets.Acti
     const coreRow = await super._renderChange(context);
     if (!context.changeType) return coreRow;
 
-    const parsed = parseModifierKey(context.change.key ?? "");
+    const key = context.change.key ?? "";
+    const parsed = parseModifierKey(key);
+    // 「＋」で足したばかりの行はキーが空。読み取れないからといって生入力に倒すと、
+    // 行を足すたびに選択式でない画面が出てしまう。未選択として選択式のまま出す
+    const isNew = key === "";
 
     return foundry.applications.handlebars.renderTemplate(
       systemPath("templates/apps/effect-change.hbs"),
@@ -139,11 +143,12 @@ export class EmokloreActiveEffectConfig extends foundry.applications.sheets.Acti
           label: game.i18n.localize(`EMOKLORE.Effect.Aspect.${aspect}`),
         })),
         phases: this.#buildPhaseOptions(),
-        // 読み取れないキーは選択式で表せないので、生の入力に倒す
-        selectedTarget: parsed ? composeTargetId(parsed.target) : RAW_KEY_TARGET_ID,
+        // 読み取れないキーは選択式で表せないので、生の入力に倒す。
+        // ただし空（新しい行）は「まだ選んでいない」であって「表せない」ではない
+        selectedTarget: parsed ? composeTargetId(parsed.target) : isNew ? "" : RAW_KEY_TARGET_ID,
         selectedAspect: parsed?.aspect ?? MODIFIER_ASPECTS[0],
-        isRawKey: !parsed,
-        rawKeyTargetId: RAW_KEY_TARGET_ID,
+        isRawKey: !parsed && !isNew,
+        isNew,
       },
     );
   }
@@ -196,6 +201,13 @@ export class EmokloreActiveEffectConfig extends foundry.applications.sheets.Acti
 
     if (isRaw) {
       key.value = raw.value;
+      return;
+    }
+
+    // 未選択のまま。本体は空のキーを持つ変更を適用の対象から外すので、
+    // 選ばずに保存しても何も起きない
+    if (target.value === "") {
+      key.value = "";
       return;
     }
 

--- a/module/applications/active-effect-config.ts
+++ b/module/applications/active-effect-config.ts
@@ -1,0 +1,211 @@
+import type { EffectChangeData } from "@common/documents/_types.mjs";
+import { systemPath } from "../constants";
+import {
+  composeModifierKey,
+  composeTargetId,
+  GLOBAL_TARGET_ID,
+  MODIFIER_ASPECTS,
+  type ModifierAspect,
+  type ModifierCollection,
+  parseModifierKey,
+  parseTargetId,
+} from "../utils/effect-keys";
+import { typedEntries } from "../utils/object";
+
+/**
+ * 「キーを直接書く」を表す選択肢の値。
+ *
+ * `system.initiative` のように選択式で扱えないキーもあるので、逃げ道を1つ残す。
+ * ここを塞ぐと、すでに載っている有効な効果が編集できなくなる。
+ */
+const RAW_KEY_TARGET_ID = "__raw";
+
+type Option = { value: string; label: string };
+type OptionGroup = { label: string; options: Option[] };
+
+/**
+ * 本体の `_renderChange` が受け取る文脈。
+ *
+ * 本体の型はJSDoc由来で名前を持たないため、同じ形をこちらで書く。`changeType` は
+ * 本体が `_renderChange` の中で入れるもので、種別が登録されていないと `undefined`。
+ */
+type ChangeRenderContext = {
+  change: EffectChangeData;
+  index: number;
+  fields: Record<string, foundry.data.fields.DataField>;
+  defaultPriority: number;
+  changeTypes: Record<string, string>;
+  changeType?: unknown;
+};
+
+/** 修正の適用先の選択肢。表ごとに optgroup へ分ける */
+const buildTargetGroups = (): OptionGroup[] => {
+  const { characteristics, skillGroups, skills, baseSkills } = CONFIG.EMOKLORE;
+  const localize = (key: string) => game.i18n.localize(key);
+
+  const toOptions = <K extends string>(
+    collection: ModifierCollection,
+    table: Record<K, { label: string }>,
+    decorate: (key: K, label: string) => string = (_key, label) => label,
+  ): Option[] =>
+    typedEntries(table).map(([key, { label }]) => ({
+      value: composeTargetId({ kind: "collection", collection, key }),
+      label: decorate(key, label),
+    }));
+
+  return [
+    {
+      label: localize("EMOKLORE.Effect.TargetGroup.global"),
+      options: [
+        { value: GLOBAL_TARGET_ID, label: localize("EMOKLORE.Effect.TargetGroup.everyRoll") },
+      ],
+    },
+    {
+      label: localize("EMOKLORE.Effect.TargetGroup.characteristics"),
+      options: toOptions("characteristics", characteristics),
+    },
+    {
+      label: localize("EMOKLORE.Effect.TargetGroup.skillGroups"),
+      options: toOptions("skillGroups", skillGroups),
+    },
+    {
+      // ★ はエクストラ技能の印。シートやチャットの表記と揃える
+      label: localize("EMOKLORE.Effect.TargetGroup.skills"),
+      options: toOptions("skills", skills, (key, label) =>
+        skills[key].isExtra ? `★${label}` : label,
+      ),
+    },
+    {
+      // ＊ は基本技能の印。技能グループと綴りが同じキーがあるので、印で見分けが付く
+      label: localize("EMOKLORE.Effect.TargetGroup.baseSkills"),
+      options: toOptions("baseSkills", baseSkills, (_key, label) => `＊${label}`),
+    },
+    {
+      label: localize("EMOKLORE.Effect.TargetGroup.other"),
+      options: [
+        { value: RAW_KEY_TARGET_ID, label: localize("EMOKLORE.Effect.TargetGroup.rawKey") },
+      ],
+    },
+  ];
+};
+
+/**
+ * 効果の設定シート。
+ *
+ * 本体との違いは変更行だけ。属性キーを手打ちさせるかわりに「対象 × 種類」の2段の
+ * 選択で組み立てさせ、あわせて本体が hidden でしか持っていない `phase` を出す。
+ *
+ * `phase` を出すのが地味に効く。v14 の `final` は `prepareDerivedData` の後に走るので
+ * 行動値やHP最大値に効果を乗せられるが、本体のシートからは選べない。
+ */
+export class EmokloreActiveEffectConfig extends foundry.applications.sheets.ActiveEffectConfig {
+  static override DEFAULT_OPTIONS = {
+    ...super.DEFAULT_OPTIONS,
+    // 自前のCSSは .emoklore の下に書いてあるので、印を付けて届くようにする
+    classes: [...super.DEFAULT_OPTIONS.classes, "emoklore"],
+    // 本体の既定は560px。キーを2列に割ったぶん列が増えるので広げる
+    position: { ...super.DEFAULT_OPTIONS.position, width: 720 },
+  };
+
+  static override PARTS = {
+    ...super.PARTS,
+    changes: {
+      template: systemPath("templates/apps/effect-changes.hbs"),
+      templates: [systemPath("templates/apps/effect-change.hbs")],
+      scrollable: ["ol[data-changes]"],
+    },
+  };
+
+  /**
+   * 変更行1つぶんを描く。
+   *
+   * 前処理（`*Path` の組み立てと、文字列でない効果値の JSON 化）は本体に任せたいので
+   * 一度 `super` を通す。戻ってきたHTMLを使うのは、登録されていない種別で本体が
+   * 警告を出す場合だけ。
+   */
+  protected override async _renderChange(context: ChangeRenderContext): Promise<string> {
+    const coreRow = await super._renderChange(context);
+    if (!context.changeType) return coreRow;
+
+    const parsed = parseModifierKey(context.change.key ?? "");
+
+    return foundry.applications.handlebars.renderTemplate(
+      systemPath("templates/apps/effect-change.hbs"),
+      {
+        ...context,
+        targetGroups: buildTargetGroups(),
+        aspects: MODIFIER_ASPECTS.map((aspect) => ({
+          value: aspect,
+          label: game.i18n.localize(`EMOKLORE.Effect.Aspect.${aspect}`),
+        })),
+        phases: this.#buildPhaseOptions(),
+        // 読み取れないキーは選択式で表せないので、生の入力に倒す
+        selectedTarget: parsed ? composeTargetId(parsed.target) : RAW_KEY_TARGET_ID,
+        selectedAspect: parsed?.aspect ?? MODIFIER_ASPECTS[0],
+        isRawKey: !parsed,
+        rawKeyTargetId: RAW_KEY_TARGET_ID,
+      },
+    );
+  }
+
+  /**
+   * 適用の段階。`initial` は素の値に、`final` は派生値の計算が済んだあとに乗る。
+   *
+   * 本体は `EFFECT.CHANGES.PHASES.*` の翻訳を持っているが、どちらを選べばよいかは
+   * システムごとの事情なので、こちらの言葉で説明を添える。
+   */
+  #buildPhaseOptions(): Option[] {
+    return typedEntries(ActiveEffect.CHANGE_PHASES).map(([value]) => ({
+      value,
+      label: game.i18n.localize(`EMOKLORE.Effect.Phase.${value}`),
+    }));
+  }
+
+  override async _onRender(
+    context: Record<string, unknown>,
+    options: Record<string, unknown>,
+  ): Promise<void> {
+    await super._onRender(context, options);
+
+    // 2つの選択と生入力から属性キーを組み立てて、送信される hidden に書き戻す。
+    // 行ごとに閉じているので、行を足しても消しても他の行に影響しない
+    for (const row of this.element.querySelectorAll<HTMLElement>("[data-change-row]")) {
+      const sync = () => EmokloreActiveEffectConfig.#syncKey(row);
+      for (const control of row.querySelectorAll<HTMLElement>("[data-change-key-part]")) {
+        control.addEventListener("change", sync);
+      }
+      sync();
+    }
+  }
+
+  /**
+   * 行の入力から属性キーを決めて hidden に入れ、生入力の出し入れを切り替える。
+   *
+   * hidden にだけ `name` を付けてあるので、送信されるのは常に組み立て済みのキー1つ。
+   */
+  static #syncKey(row: HTMLElement): void {
+    const target = row.querySelector<HTMLSelectElement>("[data-change-key-part=target]");
+    const aspect = row.querySelector<HTMLSelectElement>("[data-change-key-part=aspect]");
+    const raw = row.querySelector<HTMLInputElement>("[data-change-key-part=raw]");
+    const key = row.querySelector<HTMLInputElement>("[data-change-key]");
+    if (!target || !aspect || !raw || !key) return;
+
+    const isRaw = target.value === RAW_KEY_TARGET_ID;
+    raw.hidden = !isRaw;
+    aspect.hidden = isRaw;
+
+    if (isRaw) {
+      key.value = raw.value;
+      return;
+    }
+
+    const parsedTarget = parseTargetId(target.value);
+    // 選択肢は自分で作っているので通らないはずだが、通らなければキーを触らない
+    if (!parsedTarget) return;
+
+    key.value = composeModifierKey({
+      target: parsedTarget,
+      aspect: aspect.value as ModifierAspect,
+    });
+  }
+}

--- a/module/emoklore.ts
+++ b/module/emoklore.ts
@@ -1,6 +1,7 @@
 // このimportがビルド時のCSS出力のトリガになる。外すと dist/emoklore.css が
 // 生成されず、system.json の styles が指す先がなくなる（型の宣言は types/css.d.ts）
 import "../css/emoklore.css";
+import { EmokloreActiveEffectConfig } from "./applications/active-effect-config";
 import * as applications from "./applications/character-sheet";
 import { EmokloreWeaponSheet } from "./applications/weapon-sheet";
 import { EMOKLORE } from "./config/index";
@@ -101,6 +102,18 @@ Hooks.once("init", () => {
       types: ["weapon"],
       makeDefault: true,
       label: "EMOKLORE.Sheet.class.weapon",
+    },
+  );
+
+  // 効果の設定シート。属性キーを手打ちさせないための差し替えで、種別は base 一択
+  DocumentSheetConfig.registerSheet(
+    ActiveEffect,
+    "emoklore",
+    // biome-ignore lint: 本体のコンストラクタ型がジェネリクス開放のため素の as では通らない
+    EmokloreActiveEffectConfig as unknown as typeof foundry.applications.api.ApplicationV2,
+    {
+      makeDefault: true,
+      label: "EMOKLORE.Sheet.class.activeEffect",
     },
   );
 });

--- a/module/utils/effect-keys.test.ts
+++ b/module/utils/effect-keys.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import {
+  composeModifierKey,
+  composeTargetId,
+  type ModifierChangeKey,
+  parseModifierKey,
+  parseTargetId,
+} from "./effect-keys";
+
+describe("composeModifierKey", () => {
+  it("全体修正は表を挟まない", () => {
+    expect(composeModifierKey({ target: { kind: "global" }, aspect: "target" })).toBe(
+      "system.mod.target",
+    );
+  });
+
+  it("表に属する修正は表とキーを挟む", () => {
+    expect(
+      composeModifierKey({
+        target: { kind: "collection", collection: "characteristics", key: "mentality" },
+        aspect: "bonus",
+      }),
+    ).toBe("system.characteristics.mentality.mod.bonus");
+  });
+});
+
+describe("parseModifierKey", () => {
+  const cases: [string, ModifierChangeKey][] = [
+    ["system.mod.bonus", { target: { kind: "global" }, aspect: "bonus" }],
+    [
+      "system.characteristics.physical.mod.success",
+      {
+        target: { kind: "collection", collection: "characteristics", key: "physical" },
+        aspect: "success",
+      },
+    ],
+    [
+      "system.skillGroups.negotiations.mod.success",
+      {
+        target: { kind: "collection", collection: "skillGroups", key: "negotiations" },
+        aspect: "success",
+      },
+    ],
+    [
+      "system.skills.keenObservation.mod.target",
+      {
+        target: { kind: "collection", collection: "skills", key: "keenObservation" },
+        aspect: "target",
+      },
+    ],
+    [
+      "system.baseSkills.investigation.mod.bonus",
+      {
+        target: { kind: "collection", collection: "baseSkills", key: "investigation" },
+        aspect: "bonus",
+      },
+    ],
+  ];
+
+  for (const [key, expected] of cases) {
+    it(`${key} を読み取る`, () => {
+      expect(parseModifierKey(key)).toEqual(expected);
+    });
+  }
+
+  it("組み立てたキーは読み戻せる", () => {
+    for (const [key, parsed] of cases) {
+      expect(composeModifierKey(parsed)).toBe(key);
+    }
+  });
+
+  // null は「選択式では扱えない」の合図。シートはこれを見て生の入力に倒すので、
+  // ここで弾いたキーも効果としては有効なまま編集できる
+  const rejected = [
+    "system.initiative",
+    "system.resources.hp.max",
+    "system.characteristics.physical.value",
+    "system.mod.unknown",
+    "system.unknownTable.foo.mod.bonus",
+    "system.skills.search.mod",
+    "system.skills.mod.bonus",
+    "characteristics.physical.mod.bonus",
+    "flags.emoklore.foo",
+    "",
+  ];
+
+  for (const key of rejected) {
+    it(`${key || "（空文字）"} は選択式では扱わない`, () => {
+      expect(parseModifierKey(key)).toBeNull();
+    });
+  }
+
+  it("表の名前が合っていても大文字小文字が違えば読み取らない", () => {
+    expect(parseModifierKey("system.Skills.search.mod.bonus")).toBeNull();
+  });
+});
+
+describe("composeTargetId / parseTargetId", () => {
+  it("全体修正は global で表す", () => {
+    expect(composeTargetId({ kind: "global" })).toBe("global");
+    expect(parseTargetId("global")).toEqual({ kind: "global" });
+  });
+
+  it("表に属するものは 表.キー で表す", () => {
+    const target = { kind: "collection", collection: "skills", key: "search" } as const;
+    expect(composeTargetId(target)).toBe("skills.search");
+    expect(parseTargetId("skills.search")).toEqual(target);
+  });
+
+  it("知らない表は読み取らない", () => {
+    expect(parseTargetId("unknownTable.foo")).toBeNull();
+    expect(parseTargetId("skills")).toBeNull();
+    expect(parseTargetId("")).toBeNull();
+  });
+});

--- a/module/utils/effect-keys.ts
+++ b/module/utils/effect-keys.ts
@@ -1,0 +1,91 @@
+/**
+ * ActiveEffectの属性キーの組み立てと読み取り。
+ *
+ * 効果タブで扱うキーは `system.<表>.<キー>.mod.<種類>` と、全体修正の
+ * `system.mod.<種類>` の2形しかない。シートはこの2形だけを選択式で見せ、
+ * それ以外のキー（`system.initiative` など）は生の入力に倒す。
+ *
+ * `CONFIG` を読まないので単体テストできる。選択肢のラベルを作るのは
+ * `CONFIG.EMOKLORE` を持っている applications 側の仕事。
+ */
+
+/** 修正の種類。ModifierSet の3値に対応する */
+export const MODIFIER_ASPECTS = ["bonus", "target", "success"] as const;
+export type ModifierAspect = (typeof MODIFIER_ASPECTS)[number];
+
+/** 修正を持つ表。全体修正だけはどの表にも属さない */
+export const MODIFIER_COLLECTIONS = [
+  "characteristics",
+  "skillGroups",
+  "skills",
+  "baseSkills",
+] as const;
+export type ModifierCollection = (typeof MODIFIER_COLLECTIONS)[number];
+
+/**
+ * 修正の適用先。
+ *
+ * 判別可能unionにしてあるので、「全体修正なのにキーを持つ」ような
+ * 組み合わせを作れない。
+ */
+export type ModifierTarget =
+  | { kind: "global" }
+  | { kind: "collection"; collection: ModifierCollection; key: string };
+
+export type ModifierChangeKey = {
+  target: ModifierTarget;
+  aspect: ModifierAspect;
+};
+
+/** 適用先を選択肢の値ひとつで表すときの文字列。全体は `global` */
+export const GLOBAL_TARGET_ID = "global";
+
+const MODIFIER_KEY_PATTERN =
+  /^system\.(?:(characteristics|skillGroups|skills|baseSkills)\.([A-Za-z][A-Za-z0-9]*)\.)?mod\.(bonus|target|success)$/;
+
+/** `{ 適用先, 種類 }` から属性キーを組み立てる */
+export const composeModifierKey = ({ target, aspect }: ModifierChangeKey): string =>
+  target.kind === "global"
+    ? `system.mod.${aspect}`
+    : `system.${target.collection}.${target.key}.mod.${aspect}`;
+
+/**
+ * 属性キーを読み取る。修正のキーでなければ `null`。
+ *
+ * `null` は失敗ではなく「選択式では扱えないキー」の合図で、シートはこれを見て
+ * 生の入力に切り替える。ここで弾いたキーも効果としては有効なので、
+ * 編集できなくしてはいけない。
+ */
+export const parseModifierKey = (key: string): ModifierChangeKey | null => {
+  const match = MODIFIER_KEY_PATTERN.exec(key);
+  if (!match) return null;
+
+  const [, collection, entryKey, aspect] = match;
+  // パターンが捕まえている以上この3つの形は保証されるが、型の上では省略可能なので確かめる
+  if (!aspect || !isModifierAspect(aspect)) return null;
+
+  if (!collection) return { target: { kind: "global" }, aspect };
+  if (!entryKey || !isModifierCollection(collection)) return null;
+
+  return { target: { kind: "collection", collection, key: entryKey }, aspect };
+};
+
+/** 適用先を選択肢の値に直す。`global` か `skills.search` の形 */
+export const composeTargetId = (target: ModifierTarget): string =>
+  target.kind === "global" ? GLOBAL_TARGET_ID : `${target.collection}.${target.key}`;
+
+/** 選択肢の値から適用先に戻す。表の名前として通らなければ `null` */
+export const parseTargetId = (id: string): ModifierTarget | null => {
+  if (id === GLOBAL_TARGET_ID) return { kind: "global" };
+
+  const [collection, key] = id.split(".");
+  if (!collection || !key || !isModifierCollection(collection)) return null;
+
+  return { kind: "collection", collection, key };
+};
+
+const isModifierAspect = (value: string): value is ModifierAspect =>
+  (MODIFIER_ASPECTS as readonly string[]).includes(value);
+
+const isModifierCollection = (value: string): value is ModifierCollection =>
+  (MODIFIER_COLLECTIONS as readonly string[]).includes(value);

--- a/templates/apps/effect-change.hbs
+++ b/templates/apps/effect-change.hbs
@@ -19,6 +19,10 @@
 
   <div class="em-effect-change__target">
     <select data-change-key-part="target" aria-label='{{localize "EMOKLORE.Effect.Target"}}'>
+      {{! 足したばかりの行はここが選ばれている。選ぶまでキーは空のまま }}
+      <option value="" disabled {{#if isNew}}selected{{/if}}>
+        {{localize "EMOKLORE.Effect.TargetGroup.unselected"}}
+      </option>
       {{#each targetGroups as |group|}}
         <optgroup label="{{group.label}}">
           {{#each group.options as |option|}}

--- a/templates/apps/effect-change.hbs
+++ b/templates/apps/effect-change.hbs
@@ -1,0 +1,85 @@
+{{!--
+  変更行1つ。本体の change.hbs を置き換えたもの。
+
+  属性キーは「対象」と「種類」の2つの選択から組み立てて hidden に入れる。
+  `name` を持つのはその hidden だけなので、送信されるのは常に組み立て済みのキー1つ。
+  組み立ては active-effect-config.ts の #syncKey が行う。
+
+  @param change          本体が組み立てた変更（*Path 付き）
+  @param targetGroups    対象の選択肢。optgroup ごとの配列
+  @param aspects         修正の種類（ダイスボーナス／判定値／成功数）
+  @param phases          適用の段階（initial / final）
+  @param selectedTarget  いま選ばれている対象。読み取れないキーなら rawKeyTargetId
+  @param selectedAspect  いま選ばれている種類
+  @param isRawKey        キーを直接書くモードか
+--}}
+<li class="em-effect-change" data-index="{{index}}" data-change-row>
+  {{! 送信されるのはこれだけ。2つの選択にも生入力にも name は付けない }}
+  <input type="hidden" name="{{change.keyPath}}" value="{{change.key}}" data-change-key />
+
+  <div class="em-effect-change__target">
+    <select data-change-key-part="target" aria-label='{{localize "EMOKLORE.Effect.Target"}}'>
+      {{#each targetGroups as |group|}}
+        <optgroup label="{{group.label}}">
+          {{#each group.options as |option|}}
+            <option
+              value="{{option.value}}"
+              {{#if (eq option.value @root.selectedTarget)}}selected{{/if}}
+            >{{option.label}}</option>
+          {{/each}}
+        </optgroup>
+      {{/each}}
+    </select>
+  </div>
+
+  <div class="em-effect-change__aspect">
+    <select
+      data-change-key-part="aspect"
+      aria-label='{{localize "EMOKLORE.Effect.Aspect.Label"}}'
+      {{#if isRawKey}}hidden{{/if}}
+    >
+      {{#each aspects as |aspect|}}
+        <option
+          value="{{aspect.value}}"
+          {{#if (eq aspect.value @root.selectedAspect)}}selected{{/if}}
+        >{{aspect.label}}</option>
+      {{/each}}
+    </select>
+
+    {{! 選択式で扱えないキー（system.initiative など）の逃げ道 }}
+    <input
+      type="text"
+      data-change-key-part="raw"
+      value="{{change.key}}"
+      aria-label='{{localize "EFFECT.FIELDS.changes.element.key.label"}}'
+      placeholder="system.initiative"
+      {{#unless isRawKey}}hidden{{/unless}}
+    />
+  </div>
+
+  <div class="em-effect-change__type">
+    {{formInput fields.type name=change.typePath value=change.type choices=changeTypes}}
+  </div>
+
+  <div class="em-effect-change__value">
+    {{formInput fields.value name=change.valuePath value=change.value elementType="input"}}
+  </div>
+
+  <div class="em-effect-change__phase">
+    {{formInput fields.phase name=change.phasePath value=change.phase choices=phases
+                labelAttr="label" valueAttr="value"}}
+  </div>
+
+  <div class="em-effect-change__priority">
+    {{formInput fields.priority name=change.priorityPath value=change.priority
+                placeholder=defaultPriority}}
+  </div>
+
+  <div class="em-effect-change__controls">
+    <button
+      type="button"
+      class="inline-control icon fa-solid fa-trash"
+      data-action="deleteChange"
+    ></button>
+  </div>
+</li>

--- a/templates/apps/effect-changes.hbs
+++ b/templates/apps/effect-changes.hbs
@@ -1,0 +1,34 @@
+{{!--
+  効果の「変更」タブ。本体の changes.hbs を置き換えたもの。
+
+  違いは見出しの列で、属性キー1列だったところを「対象／種類」の2列に割り、
+  本体が hidden でしか持っていない「段階」を1列足している。
+  行の中身は effect-change.hbs が描く。
+--}}
+<section
+  class="tab changes em-effect-changes{{#if tab.active}} active{{/if}}"
+  data-group="{{tab.group}}"
+  data-tab="{{tab.id}}"
+>
+  <header class="em-effect-changes__head">
+    <div>{{localize "EMOKLORE.Effect.Target"}}</div>
+    <div>{{localize "EMOKLORE.Effect.Aspect.Label"}}</div>
+    <div>{{localize "EFFECT.FIELDS.changes.element.type.label"}}</div>
+    <div>{{localize "EFFECT.FIELDS.changes.element.value.label"}}</div>
+    <div>{{localize "EMOKLORE.Effect.Phase.Label"}}</div>
+    <div>{{localize "EFFECT.FIELDS.changes.element.priority.label"}}</div>
+    <div class="em-effect-changes__controls">
+      <button
+        type="button"
+        class="inline-control icon fa-regular fa-square-plus"
+        data-action="addChange"
+      ></button>
+    </div>
+  </header>
+
+  <ol class="scrollable em-effect-changes__body" data-changes>
+    {{#each changes as |change|}}
+      {{{change}}}
+    {{/each}}
+  </ol>
+</section>

--- a/tests/live/checks/active-effect.mjs
+++ b/tests/live/checks/active-effect.mjs
@@ -248,6 +248,183 @@ export async function run({ page, check }) {
     ),
   );
 
+  await check("差し替えた効果シートが使われる", () =>
+    assertInPage(
+      page,
+      async (tag) => {
+        // 登録表ではなく、実際に効果が開くシートを見る。
+        // getSheetClassesForSubType が返すのは id とラベルで、クラスではない
+        const a = game.actors.getName(`${tag}_char`);
+        const [effect] = await a.createEmbeddedDocuments("ActiveEffect", [
+          { name: `${tag}_sheet`, system: { changes: [] } },
+        ]);
+        const name = effect.sheet?.constructor?.name;
+        await effect.delete();
+
+        const ok = name === "EmokloreActiveEffectConfig";
+        return { ok, detail: ok ? name : `使われたシート=${name}` };
+      },
+      TAG,
+    ),
+  );
+
+  await check("修正のキーが対象と種類の選択に分解される", () =>
+    assertInPage(
+      page,
+      async (tag) => {
+        const a = game.actors.getName(`${tag}_char`);
+        const [effect] = await a.createEmbeddedDocuments("ActiveEffect", [
+          {
+            name: `${tag}_sheet`,
+            system: {
+              changes: [
+                {
+                  key: "system.characteristics.mentality.mod.bonus",
+                  type: "add",
+                  value: 1,
+                  phase: "initial",
+                },
+              ],
+            },
+          },
+        ]);
+        try {
+          await effect.sheet.render(true);
+          await window.__waitFor(() => effect.sheet.element?.querySelector("[data-change-row]"), {
+            label: "変更行の描画",
+          });
+          const row = effect.sheet.element.querySelector("[data-change-row]");
+          const target = row.querySelector("[data-change-key-part=target]");
+          const aspect = row.querySelector("[data-change-key-part=aspect]");
+          const raw = row.querySelector("[data-change-key-part=raw]");
+          const phase = row.querySelector("[name$='.phase']");
+
+          const ok =
+            target?.value === "characteristics.mentality" &&
+            aspect?.value === "bonus" &&
+            raw?.hidden === true &&
+            // 本体は phase を hidden でしか持たない。選べることがこの差し替えの主眼
+            phase?.tagName === "SELECT";
+
+          return {
+            ok,
+            detail: ok
+              ? `対象=${target.value} 種類=${aspect.value} 段階は${phase.tagName}で選べる`
+              : `対象=${target?.value} 種類=${aspect?.value} 生入力hidden=${raw?.hidden} 段階=${phase?.tagName}`,
+          };
+        } finally {
+          await effect.sheet.close();
+          await effect.delete();
+        }
+      },
+      TAG,
+    ),
+  );
+
+  await check("選択を変えると属性キーが組み立て直される", () =>
+    assertInPage(
+      page,
+      async (tag) => {
+        const a = game.actors.getName(`${tag}_char`);
+        const [effect] = await a.createEmbeddedDocuments("ActiveEffect", [
+          {
+            name: `${tag}_sheet`,
+            system: {
+              changes: [{ key: "system.mod.bonus", type: "add", value: 1, phase: "initial" }],
+            },
+          },
+        ]);
+        try {
+          await effect.sheet.render(true);
+          await window.__waitFor(() => effect.sheet.element?.querySelector("[data-change-row]"), {
+            label: "変更行の描画",
+          });
+          const row = effect.sheet.element.querySelector("[data-change-row]");
+          const target = row.querySelector("[data-change-key-part=target]");
+          const aspect = row.querySelector("[data-change-key-part=aspect]");
+          const key = row.querySelector("[data-change-key]");
+
+          const before = key.value;
+          target.value = "skills.search";
+          target.dispatchEvent(new Event("change", { bubbles: true }));
+          aspect.value = "success";
+          aspect.dispatchEvent(new Event("change", { bubbles: true }));
+          const after = key.value;
+
+          // 生入力へ倒したら、そちらの値がそのままキーになる
+          target.value = "__raw";
+          target.dispatchEvent(new Event("change", { bubbles: true }));
+          const rawInput = row.querySelector("[data-change-key-part=raw]");
+          rawInput.value = "system.initiative";
+          rawInput.dispatchEvent(new Event("change", { bubbles: true }));
+          const rawKey = key.value;
+
+          const ok =
+            before === "system.mod.bonus" &&
+            after === "system.skills.search.mod.success" &&
+            rawKey === "system.initiative" &&
+            rawInput.hidden === false;
+
+          return {
+            ok,
+            detail: ok
+              ? `${before} → ${after} → ${rawKey}（生入力）`
+              : `前=${before} 後=${after} 生=${rawKey} hidden=${rawInput.hidden}`,
+          };
+        } finally {
+          await effect.sheet.close();
+          await effect.delete();
+        }
+      },
+      TAG,
+    ),
+  );
+
+  await check("選択式で扱えないキーは生入力に倒れる", () =>
+    assertInPage(
+      page,
+      async (tag) => {
+        const a = game.actors.getName(`${tag}_char`);
+        const [effect] = await a.createEmbeddedDocuments("ActiveEffect", [
+          {
+            name: `${tag}_sheet`,
+            system: {
+              changes: [{ key: "system.initiative", type: "add", value: 2, phase: "final" }],
+            },
+          },
+        ]);
+        try {
+          await effect.sheet.render(true);
+          await window.__waitFor(() => effect.sheet.element?.querySelector("[data-change-row]"), {
+            label: "変更行の描画",
+          });
+          const row = effect.sheet.element.querySelector("[data-change-row]");
+          const target = row.querySelector("[data-change-key-part=target]");
+          const raw = row.querySelector("[data-change-key-part=raw]");
+          const aspect = row.querySelector("[data-change-key-part=aspect]");
+
+          // ここを塞ぐと、載っている有効な効果が編集できなくなる
+          const ok =
+            target?.value === "__raw" &&
+            raw?.value === "system.initiative" &&
+            raw?.hidden === false &&
+            aspect?.hidden === true;
+
+          return {
+            ok,
+            detail: ok
+              ? `対象=その他 生入力=${raw.value}`
+              : `対象=${target?.value} 生入力=${raw?.value} hidden=${raw?.hidden}`,
+          };
+        } finally {
+          await effect.sheet.close();
+          await effect.delete();
+        }
+      },
+      TAG,
+    ),
+  );
+
   await check("一時的効果の作成が duration を持つ", () =>
     assertInPage(
       page,

--- a/tests/live/checks/active-effect.mjs
+++ b/tests/live/checks/active-effect.mjs
@@ -268,7 +268,7 @@ export async function run({ page, check }) {
     ),
   );
 
-  await check("修正のキーが対象と種類の選択に分解される", () =>
+  await check("修正のキーが対象と修正先の選択に分解される", () =>
     assertInPage(
       page,
       async (tag) => {
@@ -309,8 +309,8 @@ export async function run({ page, check }) {
           return {
             ok,
             detail: ok
-              ? `対象=${target.value} 種類=${aspect.value} 段階は${phase.tagName}で選べる`
-              : `対象=${target?.value} 種類=${aspect?.value} 生入力hidden=${raw?.hidden} 段階=${phase?.tagName}`,
+              ? `対象=${target.value} 修正先=${aspect.value} 段階は${phase.tagName}で選べる`
+              : `対象=${target?.value} 修正先=${aspect?.value} 生入力hidden=${raw?.hidden} 段階=${phase?.tagName}`,
           };
         } finally {
           await effect.sheet.close();
@@ -370,6 +370,56 @@ export async function run({ page, check }) {
             detail: ok
               ? `${before} → ${after} → ${rawKey}（生入力）`
               : `前=${before} 後=${after} 生=${rawKey} hidden=${rawInput.hidden}`,
+          };
+        } finally {
+          await effect.sheet.close();
+          await effect.delete();
+        }
+      },
+      TAG,
+    ),
+  );
+
+  await check("足したばかりの行は選択式で始まる", () =>
+    assertInPage(
+      page,
+      async (tag) => {
+        const a = game.actors.getName(`${tag}_char`);
+        const [effect] = await a.createEmbeddedDocuments("ActiveEffect", [
+          { name: `${tag}_sheet`, system: { changes: [] } },
+        ]);
+        try {
+          await effect.sheet.render(true);
+          await window.__waitFor(
+            () => effect.sheet.element?.querySelector("[data-action=addChange]"),
+            {
+              label: "変更タブの描画",
+            },
+          );
+          // 本体の #onAddChange は key が空の行を足す。空を「読み取れないキー」と
+          // 同じ扱いにすると、行を足すたびに生入力が出てしまう
+          effect.sheet.element.querySelector("[data-action=addChange]").click();
+          await window.__waitFor(() => effect.sheet.element?.querySelector("[data-change-row]"), {
+            label: "追加した変更行",
+          });
+
+          const row = effect.sheet.element.querySelector("[data-change-row]");
+          const target = row.querySelector("[data-change-key-part=target]");
+          const raw = row.querySelector("[data-change-key-part=raw]");
+          const aspect = row.querySelector("[data-change-key-part=aspect]");
+          const key = row.querySelector("[data-change-key]");
+
+          const ok =
+            target?.value === "" &&
+            raw?.hidden === true &&
+            aspect?.hidden === false &&
+            key?.value === "";
+
+          return {
+            ok,
+            detail: ok
+              ? "対象は未選択、生入力は出ない、キーは空のまま"
+              : `対象=${target?.value} 生入力hidden=${raw?.hidden} 修正先hidden=${aspect?.hidden} キー=${key?.value}`,
           };
         } finally {
           await effect.sheet.close();


### PR DESCRIPTION
ActiveEffect本格導入の3本目。#63 の上に積んでいる。

## 属性キーを選ぶものにした

189本のキーから手打ちさせていた。`docs/active-effect.md` が「大文字小文字も含めて誤字があると動作しない」と警告している状態で、綴りを1文字間違えると本体は黙って何もしない。

「対象（64件）」と「修正先（3件）」の2段の選択にして、キーは内部で組み立てる。**保存されるキー文字列はこれまでと同じ**なので、既存の効果はそのまま動く。

対象は optgroup で 全体(1) / 能力値(8) / 技能グループ(7) / 技能(35) / 基本技能(13) に分けてある。基本技能は `＊`、エクストラ技能は `★` を頭に付けてシートやチャットの表記と揃えた（技能グループと基本技能には綴りが同じキーがあるので、印が無いと見分けが付かない）。

```
対象              修正先      種別    効果値   段階     優先度
身体          ▼   成功数  ▼   追加 ▼   -1      通常  ▼   20
すべての判定   ▼   判定値  ▼   追加 ▼   -2      通常  ▼   20
キーを直接指定 ▼   system.initiative  追加 ▼   2   計算後 ▼   20
```

## 段階（phase）を選べるようにした

本体のシートは `phase` を hidden でしか持たない。つまり**本体のUIからは `final` を選ぶ手段が無い**。派生値（行動値・HP最大値）に効果を乗せられるのは `final` だけなので、実質そこが塞がっていた。

## 逃げ道を残した

選択式で扱えないキー（`system.initiative` など）は「キーを直接指定」に倒れて生の入力になる。ここを塞ぐと、すでに載っている有効な効果が編集できなくなる。

dnd5e にはキー補完のUIが無く（Wikiリンクのツールチップ1個だけ）、参考にできる前例が無かったので、この形にしている。

## 実機検証を32件→37件に

| 検証 | 結果 |
|---|---|
| 差し替えた効果シートが使われる | `EmokloreActiveEffectConfig` |
| 修正のキーが対象と修正先の選択に分解される | 対象=`characteristics.mentality` 修正先=`bonus` 段階はSELECTで選べる |
| 選択を変えると属性キーが組み立て直される | `system.mod.bonus` → `system.skills.search.mod.success` → `system.initiative`（生入力） |
| 足したばかりの行は選択式で始まる | 対象は未選択、生入力は出ない、キーは空のまま |
| 選択式で扱えないキーは生入力に倒れる | 対象=その他 生入力=`system.initiative` |

4件目は実装中に見つけた不具合の回帰テスト。本体の `#onAddChange` はキーが空の行を足すので、空を「読み取れないキー」と同じ扱いにしていたぶん、「＋」を押すたびに生入力の行が出ていた。

## 残していること

見た目と表示文言の細かい調整はこのPRでは追い込んでいない。列名・段階のラベル（通常／計算後）・対象の並び順あたりは実際に使いながら詰めたい。