### PR TITLE
Biomeのバージョン3箇所の同期を機械で検査する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       # プラグイン（tools/*.grit）を使うのでバージョンを固定する。
-      # package.json の @biomejs/biome と揃えること
+      # package.json / biome.json の $schema と揃えること
+      # （buildジョブの check:biome-version が3箇所の一致を見ている）
       - uses: biomejs/setup-biome@v2
         with:
           version: 2.5.5
@@ -43,6 +44,8 @@ jobs:
         run: npm test
       - name: Build system
         run: npm run build
+      - name: Check Biome version sync
+        run: npm run check:biome-version
       - name: Check lang key parity
         run: npm run check:lang
       - name: Check Handlebars templates

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,10 @@ jobs:
   typecheck:
     name: Type Check
     runs-on: ubuntu-latest
-    # 公開リポジトリのActions cacheはフォークPRからrestoreできるため、フォークPRでは実行しない
+    # フォークPRにはsecretsが渡らないので、キャッシュミス時に fetch-foundry.mjs へ倒せない。
+    # 本体ソースを用意する手段が無くなるため、ジョブごと実行しない。
+    # cache自体はフォークPRからでもbase/デフォルトブランチのぶんをrestoreできるが、
+    # ミスしたときに落ちるだけのジョブは置かない
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     env:
       # ローカルのFoundry本体を更新したら合わせて上げる（世代はsystem.jsonのcompatibilityと対応）

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -105,7 +105,7 @@ Foundryは `Document#update` をサーバ側で権限検査するので、OWNER�
 3. **`config/` の副作用**: `module/config/index.ts` が import 時に `preLocalize` を呼び、`performPreLocalization` が `CONFIG.EMOKLORE` を破壊的に書き換える。この表の「`config/` に置かないもの」に反するが、dnd5e / draw-steel 由来の確立したパターンなので当面は踏襲する
 4. **`utils/charsheet-importer.ts` が2つの顔を持つ**: 純粋なパーサ（`parseSkills` / `parseEmotions` / `validateCharSheetJSON`、単体テスト済み）と、`actor.update()` と `ui.notifications` を持つ適用部（`importFromCharSheet`）が同じファイルにある。後者は `EmokloreActor` を `import type` で借りているので、**この逆依存はimportグラフに現れない**。分割は20〜30行規模だが、`buildImportIndexes()` が `CONFIG.EMOKLORE` を読むため、パーサを完全に純粋化するなら索引を引数で渡す形への変更が要る
 5. **`data/messages/weapon-card.ts` がオーケストレータ**: カードのボタンハンドラ（`rollAttack` / `rollDamage` / `applyDamage`）が `actor.buildSkillRoll()` と `applyDamageToTargets()` を駆動し、`ui.notifications` とフックも持つ。`data/` の「置かないもの: UI、チャット生成」に反する。層表の `data/` の行に `documents/` を足して解決してはいけない（表が `documents/` → `data/` を許しているので、相互依存を許可することになる）。直すならハンドラの置き場所のほう
-6. **CIの穴**: 型チェックジョブはフォークからのPRで実行されない。理由は2つ重なっており、Actions cacheがフォークから復元できないことと、secretsがフォークPRに渡らないのでキャッシュミス時の `tools/fetch-foundry.mjs` 経路も成立しないこと。lefthookには型チェックもテストも入っていない（`pre-push` 自体が無い）ので、**フォークからのPRは型チェックを一度も通さずに緑になれる**（Issue #7 の範囲）
+6. **CIの穴**: 型チェックジョブはフォークからのPRで実行されない。理由は本体ソースの調達手段が無くなることで、secretsがフォークPRに渡らないため、キャッシュミス時のフォールバックである `tools/fetch-foundry.mjs` が成立しない。**Actions cache そのものはフォークPRからでもbase/デフォルトブランチのぶんをrestoreできる**（できないのは新規cacheの保存のほう）ので、ミスしなければ動きうるが、ミスしたときに落ちるだけのジョブは置いていない。lefthookには型チェックもテストも入っていない（`pre-push` 自体が無い）ので、**フォークからのPRは型チェックを一度も通さずに緑になれる**（Issue #56）
 
 `weapon` は `documentTypes.Item.weapon` の宣言で到達可能にした（`game.documentTypes.Item` が `["base", "weapon"]` を返すことを実機で確認済み）。**新しい種別を足すときは、データモデルの登録だけでなく `system.json` の宣言が要る。**
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -93,10 +93,10 @@ feat: add resonance roll dialog
 
 ### 自動チェック
 
-- **pre-commitフック**: `npm install` 時に [lefthook](https://lefthook.dev/) がgitフックを自動セットアップし、コミット時にstagedファイルへBiomeが適用される（修正は自動でstageされる）。`.hbs` を触れば `check:templates`、`lang/*.json` を触れば `check:lang` も走る。緊急時は `git commit --no-verify` でスキップできるが非推奨
-- **CI**: pushとPRで GitHub Actions が Biome・テスト・ビルド・型チェック・翻訳/テンプレート/スキーマ表の整合チェックを実行する（`.github/workflows/ci.yml`）。マージにはCIが通ることが必要
+- **pre-commitフック**: `npm install` 時に [lefthook](https://lefthook.dev/) がgitフックを自動セットアップし、コミット時にstagedファイルへBiomeが適用される（修正は自動でstageされる）。`.hbs` を触れば `check:templates`、`lang/*.json` を触れば `check:lang`、`package.json` / `biome.json` / `ci.yml` を触れば `check:biome-version` も走る。緊急時は `git commit --no-verify` でスキップできるが非推奨
+- **CI**: pushとPRで GitHub Actions が Biome・テスト・ビルド・型チェック・翻訳/テンプレート/スキーマ表/Biomeバージョンの整合チェックを実行する（`.github/workflows/ci.yml`）。マージにはCIが通ることが必要
   - 型チェックジョブは本体ソース（`client/` + `common/`）をActions cacheで保持し、キャッシュミス時のみ `tools/fetch-foundry.mjs` がsecrets（`FOUNDRY_USERNAME` / `FOUNDRY_PASSWORD`）でfoundryvtt.comからNode配布版を取得する。フォークからのPRでは実行されない
-- **依存の更新**: DependabotがnpmとGitHub Actionsを週次で見る（`.github/dependabot.yml`）。パッチとマイナーは1本にまとめ、メジャーは個別にPRが立つ。**Biomeだけは3箇所（`package.json` / `biome.json` の `$schema` / `ci.yml` の `setup-biome`）を揃える必要がある**ので、Dependabotが上げてきたら残り2つを手で追従させる
+- **依存の更新**: DependabotがnpmとGitHub Actionsを週次で見る（`.github/dependabot.yml`）。パッチとマイナーは1本にまとめ、メジャーは個別にPRが立つ。**Biomeだけは3箇所（`package.json` / `biome.json` の `$schema` / `ci.yml` の `setup-biome`）を揃える必要がある**。Dependabotが上げてくるのは `package.json` だけなので、残り2つは手で追従させる。揃っていなければ `check:biome-version` が落ちるので、追従漏れはDependabotのPRの時点で分かる
 
 ## 表記ルール
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -20,6 +20,15 @@ pre-commit:
       glob: "lang/*.json"
       run: npm run check:lang
 
+    # Biomeのバージョンは3箇所に散っており、揃っていないとCIとローカルで違うBiomeが走る。
+    # Dependabotが上げてくるのは package.json だけなので、そのPRの時点で気付けるようにする
+    - name: biome-version
+      glob:
+        - "package.json"
+        - "biome.json"
+        - ".github/workflows/ci.yml"
+      run: npm run check:biome-version
+
 commit-msg:
   jobs:
     - name: message-format

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lint": "biome check .",
     "test": "vitest run",
     "prepare": "lefthook install",
+    "check:biome-version": "node tools/check-biome-version.mjs",
     "check:lang": "node tools/check-lang.mjs",
     "check:templates": "node tools/check-templates.mjs",
     "check:schema-doc": "node tools/check-schema-doc.mjs",

--- a/tools/check-biome-version.mjs
+++ b/tools/check-biome-version.mjs
@@ -1,0 +1,73 @@
+// Biomeのバージョンが3箇所で揃っているかチェックする
+// （package.json / biome.json の $schema / ci.yml の setup-biome）
+//
+// プラグイン（tools/*.grit）を使う都合でバージョンを固定しているため、揃っていないと
+// CIとローカルで違うBiomeが走る。追従の手順は docs/contributing.md に書いてあるが、
+// Dependabotの更新で2回続けて漏れたので機械で見る
+import { readFileSync } from "node:fs";
+
+const PACKAGE_JSON = "package.json";
+const BIOME_JSON = "biome.json";
+const CI_YML = ".github/workflows/ci.yml";
+
+/** @type {{ where: string, version: string }[]} */
+const found = [];
+const problems = [];
+
+// 1. package.json の devDependencies
+const declared = JSON.parse(readFileSync(PACKAGE_JSON, "utf-8")).devDependencies?.[
+  "@biomejs/biome"
+];
+if (declared === undefined) {
+  problems.push(`${PACKAGE_JSON}: devDependencies に @biomejs/biome が無い`);
+} else if (!/^\d+\.\d+\.\d+$/.test(declared)) {
+  // ^ や ~ が付くと他の2箇所と一致していてもローカルだけ別のBiomeが入りうるので、
+  // 完全固定であること自体を検査する
+  problems.push(
+    `${PACKAGE_JSON}: @biomejs/biome は範囲指定ではなく完全固定にする（現在: ${declared}）`,
+  );
+} else {
+  found.push({ where: `${PACKAGE_JSON} の @biomejs/biome`, version: declared });
+}
+
+// 2. biome.json の $schema。バージョンはURLの一部なので抜き出す
+const schema = JSON.parse(readFileSync(BIOME_JSON, "utf-8")).$schema;
+const schemaVersion = /schemas\/(\d+\.\d+\.\d+)\//.exec(schema ?? "")?.[1];
+if (schemaVersion === undefined) {
+  problems.push(`${BIOME_JSON}: $schema からバージョンを読めない（現在: ${schema}）`);
+} else {
+  found.push({ where: `${BIOME_JSON} の $schema`, version: schemaVersion });
+}
+
+// 3. ci.yml の setup-biome。YAMLパーサを足さずに済ませたいので、`uses:` の行を見つけて
+// 次のステップ（`- ` で始まる行）に入るまでの `version:` を拾う
+const lines = readFileSync(CI_YML, "utf-8").split("\n");
+const stepIndex = lines.findIndex((line) => /^\s*-\s*uses:\s*biomejs\/setup-biome@/.test(line));
+if (stepIndex === -1) {
+  problems.push(`${CI_YML}: biomejs/setup-biome のステップが見つからない`);
+} else {
+  let ciVersion;
+  for (const line of lines.slice(stepIndex + 1)) {
+    if (/^\s*-\s/.test(line)) break;
+    const matched = /^\s*version:\s*["']?(\S+?)["']?\s*$/.exec(line);
+    if (matched) {
+      ciVersion = matched[1];
+      break;
+    }
+  }
+  if (ciVersion === undefined) problems.push(`${CI_YML}: setup-biome に version の指定が無い`);
+  else found.push({ where: `${CI_YML} の setup-biome`, version: ciVersion });
+}
+
+const versions = new Set(found.map(({ version }) => version));
+if (versions.size > 1) {
+  problems.push("3箇所のバージョンが揃っていない");
+  for (const { where, version } of found) problems.push(`  ${version}  ← ${where}`);
+}
+
+if (problems.length > 0) {
+  console.error("Biomeのバージョンが同期していない（追従の手順は docs/contributing.md）:");
+  for (const problem of problems) console.error(`  - ${problem}`);
+  process.exit(1);
+}
+console.log(`biome version OK: 3箇所とも ${[...versions][0]}`);


### PR DESCRIPTION
Issue #57。Biomeのバージョンが3箇所（`package.json` / `biome.json` の `$schema` / `ci.yml` の `setup-biome`）で揃っているかを `tools/check-biome-version.mjs` で検査し、CIの build ジョブと lefthook の pre-commit に載せた。

プラグイン（`tools/*.grit`）を使う都合でバージョンを固定しているため、揃っていないとCIとローカルで違うBiomeが走る。手順は `docs/contributing.md` に書いてあったが、Dependabotの #51 が `package.json` だけを上げたあと残り2箇所が追従せず、次の追従も `biome.json` だけで止まって `ci.yml` が古いまま残った。2回続けて漏れているので手順の周知では守れていない。

`$schema` はバージョンをURLの一部として持つので抜き出す。`ci.yml` はYAMLパーサを足さずに済ませたいので、`setup-biome` の `uses:` の行から次のステップに入るまでの `version:` を拾う。あわせて `package.json` 側が範囲指定になっていないかも見ている。`^` が付くと他の2箇所と一致していてもローカルだけ別のBiomeが入りうるため。

lefthook は `package.json` / `biome.json` / `ci.yml` のいずれかを触ったときだけ走らせる。Dependabotが上げてくるのは `package.json` だけなので、そのPRの時点で落ちる。

4通りの壊し方（`ci.yml` だけ古い・`$schema` だけ古い・`package.json` が `^2.5.5`・`setup-biome` のステップごと消えた）で `exit 1` になることを確認した。現状は3箇所とも 2.5.5 で揃っているので、この検査自体は緑で入る。

## あわせて直したもの

`ci.yml` の型チェックジョブのコメントが「公開リポジトリのActions cacheはフォークPRからrestoreできるため、フォークPRでは実行しない」となっていて理由が繋がっていなかった。`docs/architecture.md` の課題6は逆に「復元できない」と書いていた。

GitHubのドキュメントで確認したところ、フォークPRからでもbase/デフォルトブランチのcacheはrestoreできる。できないのは新規cacheの保存のほう。つまり「復元できない」が誤りで、スキップの理由はsecretsが渡らないこと1つに絞られる。キャッシュミスしたときに `tools/fetch-foundry.mjs` へ倒せず本体ソースの調達手段が無くなるのでジョブごと実行しない、が正しい説明になる。

裏返すと、ミスしなければフォークPRでも型チェックは動きうる。Issue #56 の前提が変わるので、そちらの本文も直す。