### PR TITLE
リリースを自動化し、配布URLの方式を正す

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
         run: npm run check:templates
       - name: Check schema doc
         run: npm run check:schema-doc
+      - name: Check manifest URLs
+        run: npm run check:manifest-urls
       - name: Build docs
         run: npm run docs:build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       # プラグイン（tools/*.grit）を使うのでバージョンを固定する。
-      # package.json の @biomejs/biome と揃えること
+      # package.json / biome.json の $schema と揃えること
+      # （buildジョブの check:biome-version が3箇所の一致を見ている）
       - uses: biomejs/setup-biome@v2
         with:
           version: 2.5.5
@@ -43,6 +44,8 @@ jobs:
         run: npm test
       - name: Build system
         run: npm run build
+      - name: Check Biome version sync
+        run: npm run check:biome-version
       - name: Check lang key parity
         run: npm run check:lang
       - name: Check Handlebars templates

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,10 @@ jobs:
   typecheck:
     name: Type Check
     runs-on: ubuntu-latest
-    # 公開リポジトリのActions cacheはフォークPRからrestoreできるため、フォークPRでは実行しない
+    # フォークPRにはsecretsが渡らないので、キャッシュミス時に fetch-foundry.mjs へ倒せない。
+    # 本体ソースを用意する手段が無くなるため、ジョブごと実行しない。
+    # cache自体はフォークPRからでもbase/デフォルトブランチのぶんをrestoreできるが、
+    # ミスしたときに落ちるだけのジョブは置かない
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     env:
       # ローカルのFoundry本体を更新したら合わせて上げる（世代はsystem.jsonのcompatibilityと対応）

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,11 @@ jobs:
           fi
           echo "version OK: $declared"
 
+      # download がタグ固定URLとして version と揃っているか。ci.yml でも見ているが、
+      # 配る直前の最後の関所なのでここでも通す
+      - name: Check manifest URLs
+        run: npm run check:manifest-urls
+
       # main はドキュメントサイトのデプロイ元でもあり、版を上げないマージも通常なので
       # ここでは落とさずに知らせるだけにする
       - name: Compare version with the latest release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,98 @@
+# main宛のPRではリリース候補として検査し、GitHubでReleaseをpublishすると成果物を添付する。
+# Release（とタグ）を作るのは人で、ワークフローは成果物を載せるだけ。
+# draw-steel / ryuutama と同じ形。手順は docs/contributing.md の「リリース」
+name: Release
+
+on:
+  # develop → main が通常だが hotfix → main もありうるので、headではなくbaseで絞る
+  pull_request:
+    branches: [main]
+  release:
+    types: [published]
+
+# アセットの添付に書き込みが要る（PRのときはGitHubが読み取りに落とす）
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build & Package
+    runs-on: ubuntu-latest
+    steps:
+      # Releaseのときはタグを見る。PRのときは空になり、既定（PRのマージref）に落ちる
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.release.tag_name }}
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+
+      # 食い違ったまま配ると更新の検知が壊れる。Releaseは公開済みなので落ちると
+      # 作り直しになるが、下のPR側の通知で先に気付ける
+      - name: Check tag matches system.json version
+        if: github.event_name == 'release'
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          declared=$(node -p "require('./system.json').version")
+          if [ "$declared" != "$TAG_NAME" ]; then
+            echo "NG: タグ ($TAG_NAME) と system.json の version ($declared) が食い違っている"
+            echo "    Releaseは公開済み。system.json を直してタグごと作り直すこと"
+            exit 1
+          fi
+          echo "version OK: $declared"
+
+      # main はドキュメントサイトのデプロイ元でもあり、版を上げないマージも通常なので
+      # ここでは落とさずに知らせるだけにする
+      - name: Compare version with the latest release
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          declared=$(node -p "require('./system.json').version")
+          latest=$(gh release view --json tagName --jq .tagName 2>/dev/null || true)
+          if [ -z "$latest" ]; then
+            echo "::notice::system.json の version は $declared（既存のReleaseが見つからない）"
+          elif [ "$declared" = "$latest" ]; then
+            echo "::notice::system.json の version ($declared) が最新Release ($latest) と同じ。リリースするなら上げること"
+          else
+            echo "::notice::system.json の version は $declared（最新Releaseは $latest）"
+          fi
+
+      # ci.yml はブランチへのpushとPRでしか走らないので、Releaseのpushは素通りできる。
+      # 型チェックは本体ソースの調達が要るぶん重いので回さない（タグはCIが緑の
+      # コミットに打つ前提）が、テストは依存が無く一瞬なので通す
+      - name: Run tests
+        run: npm test
+
+      - name: Build system
+        run: npm run build
+
+      # Foundryはzip直下の system.json をまず探し、無ければ `*system.json` で終わる
+      # エントリを含むディレクトリをルートとみなして剥がす（本体の
+      # dist/packages/installer.mjs）。直下に置けばこの推測を挟まない
+      - name: Package dist.zip
+        run: cd dist && zip -rq ../dist.zip .
+
+      # PRではマージ前に中身を確かめられるよう成果物を残すだけ
+      - name: Upload artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v7
+        with:
+          name: dist
+          path: |
+            dist/system.json
+            dist.zip
+          retention-days: 7
+
+      # system.json の manifest / download が releases/latest/download/ を指しているので、
+      # publishしてからこのステップが終わるまでの数十秒は更新確認が404になる
+      - name: Attach assets to the release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: gh release upload "$TAG_NAME" dist/system.json dist.zip --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 node_modules/
 dist/
+# リリース用の成果物（release.ymlが作る。手元でビルドしたときも落ちうる）
+dist.zip
 docs/.vitepress/dist
 docs/.vitepress/cache
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -105,7 +105,7 @@ Foundryは `Document#update` をサーバ側で権限検査するので、OWNER�
 3. **`config/` の副作用**: `module/config/index.ts` が import 時に `preLocalize` を呼び、`performPreLocalization` が `CONFIG.EMOKLORE` を破壊的に書き換える。この表の「`config/` に置かないもの」に反するが、dnd5e / draw-steel 由来の確立したパターンなので当面は踏襲する
 4. **`utils/charsheet-importer.ts` が2つの顔を持つ**: 純粋なパーサ（`parseSkills` / `parseEmotions` / `validateCharSheetJSON`、単体テスト済み）と、`actor.update()` と `ui.notifications` を持つ適用部（`importFromCharSheet`）が同じファイルにある。後者は `EmokloreActor` を `import type` で借りているので、**この逆依存はimportグラフに現れない**。分割は20〜30行規模だが、`buildImportIndexes()` が `CONFIG.EMOKLORE` を読むため、パーサを完全に純粋化するなら索引を引数で渡す形への変更が要る
 5. **`data/messages/weapon-card.ts` がオーケストレータ**: カードのボタンハンドラ（`rollAttack` / `rollDamage` / `applyDamage`）が `actor.buildSkillRoll()` と `applyDamageToTargets()` を駆動し、`ui.notifications` とフックも持つ。`data/` の「置かないもの: UI、チャット生成」に反する。層表の `data/` の行に `documents/` を足して解決してはいけない（表が `documents/` → `data/` を許しているので、相互依存を許可することになる）。直すならハンドラの置き場所のほう
-6. **CIの穴**: 型チェックジョブはフォークからのPRで実行されない。理由は2つ重なっており、Actions cacheがフォークから復元できないことと、secretsがフォークPRに渡らないのでキャッシュミス時の `tools/fetch-foundry.mjs` 経路も成立しないこと。lefthookには型チェックもテストも入っていない（`pre-push` 自体が無い）ので、**フォークからのPRは型チェックを一度も通さずに緑になれる**（Issue #7 の範囲）
+6. **CIの穴**: 型チェックジョブはフォークからのPRで実行されない。理由は本体ソースの調達手段が無くなることで、secretsがフォークPRに渡らないため、キャッシュミス時のフォールバックである `tools/fetch-foundry.mjs` が成立しない。**Actions cache そのものはフォークPRからでもbase/デフォルトブランチのぶんをrestoreできる**（できないのは新規cacheの保存のほう）ので、ミスしなければ動きうるが、ミスしたときに落ちるだけのジョブは置いていない。lefthookには型チェックもテストも入っていない（`pre-push` 自体が無い）ので、**フォークからのPRは型チェックを一度も通さずに緑になれる**（Issue #56）
 
 `weapon` は `documentTypes.Item.weapon` の宣言で到達可能にした（`game.documentTypes.Item` が `["base", "weapon"]` を返すことを実機で確認済み）。**新しい種別を足すときは、データモデルの登録だけでなく `system.json` の宣言が要る。**
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -93,10 +93,10 @@ feat: add resonance roll dialog
 
 ### 自動チェック
 
-- **pre-commitフック**: `npm install` 時に [lefthook](https://lefthook.dev/) がgitフックを自動セットアップし、コミット時にstagedファイルへBiomeが適用される（修正は自動でstageされる）。`.hbs` を触れば `check:templates`、`lang/*.json` を触れば `check:lang` も走る。緊急時は `git commit --no-verify` でスキップできるが非推奨
-- **CI**: pushとPRで GitHub Actions が Biome・テスト・ビルド・型チェック・翻訳/テンプレート/スキーマ表の整合チェックを実行する（`.github/workflows/ci.yml`）。マージにはCIが通ることが必要
+- **pre-commitフック**: `npm install` 時に [lefthook](https://lefthook.dev/) がgitフックを自動セットアップし、コミット時にstagedファイルへBiomeが適用される（修正は自動でstageされる）。`.hbs` を触れば `check:templates`、`lang/*.json` を触れば `check:lang`、`package.json` / `biome.json` / `ci.yml` を触れば `check:biome-version` も走る。緊急時は `git commit --no-verify` でスキップできるが非推奨
+- **CI**: pushとPRで GitHub Actions が Biome・テスト・ビルド・型チェック・翻訳/テンプレート/スキーマ表/Biomeバージョンの整合チェックを実行する（`.github/workflows/ci.yml`）。マージにはCIが通ることが必要
   - 型チェックジョブは本体ソース（`client/` + `common/`）をActions cacheで保持し、キャッシュミス時のみ `tools/fetch-foundry.mjs` がsecrets（`FOUNDRY_USERNAME` / `FOUNDRY_PASSWORD`）でfoundryvtt.comからNode配布版を取得する。フォークからのPRでは実行されない
-- **依存の更新**: DependabotがnpmとGitHub Actionsを週次で見る（`.github/dependabot.yml`）。パッチとマイナーは1本にまとめ、メジャーは個別にPRが立つ。**Biomeだけは3箇所（`package.json` / `biome.json` の `$schema` / `ci.yml` の `setup-biome`）を揃える必要がある**ので、Dependabotが上げてきたら残り2つを手で追従させる
+- **依存の更新**: DependabotがnpmとGitHub Actionsを週次で見る（`.github/dependabot.yml`）。パッチとマイナーは1本にまとめ、メジャーは個別にPRが立つ。**Biomeだけは3箇所（`package.json` / `biome.json` の `$schema` / `ci.yml` の `setup-biome`）を揃える必要がある**。Dependabotが上げてくるのは `package.json` だけなので、残り2つは手で追従させる。揃っていなければ `check:biome-version` が落ちるので、追従漏れはDependabotのPRの時点で分かる
 
 ## 表記ルール
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -114,10 +114,20 @@ feat: add resonance roll dialog
 
 ## リリース（メンテナ向け）
 
-1. `npm run verify:live` を通す（[実機検証](/testing#実機検証)。CIでは回らないので、ここは人が確認する）
-2. `system.json` の `version` を更新する
-3. `npm run build` で `dist/` を生成し、`dist.zip` にまとめる
-4. GitHub Releaseを作成し、`system.json` と `dist.zip` を添付する（`system.json` の `manifest` / `download` URLはlatest releaseを指している）
+**Releaseとタグを作るのは人**で、`.github/workflows/release.yml` はビルドして `system.json` と `dist.zip` を添付するだけ。draw-steel / ryuutama と同じ形にしてある。
+
+1. `system.json` の `version` を更新する
+2. `npm run verify:live` を通す（[実機検証](/testing#実機検証)。CIでは回らないので、ここは人が確認する）
+3. `develop` から `main` へPRを出す。ワークフローがビルドと `dist.zip` の作成まで走らせ、成果物を artifact に残すので、**マージ前に中身を確認できる**。`version` が最新Releaseと同じままなら通知が出る（落としはしない。`main` はドキュメントサイトのデプロイ元でもあり、版を上げないマージも通常のため）
+4. マージする
+5. GitHubのReleases画面でReleaseを作る。**タグ名は `system.json` の `version` と同じにする**（`main` を対象に「Create new tag on publish」）。ノートを書いてpublishする
+6. ワークフローが `system.json` と `dist.zip` を添付する
+
+**publish直後の数十秒はアセットがまだ無い。** `system.json` の `manifest` / `download` が指す `releases/latest/download/` は、添付が終わるまで404を返す。この間に更新確認をした利用者はエラーになるので、混む時間帯を避けるとよい。
+
+タグと `system.json` の `version` が食い違っていたらワークフローが止まる。食い違ったまま配ると更新の検知が壊れるため。ただしその時点でReleaseは公開済みなので、直してタグごと作り直すことになる。**3の通知はこれを事前に拾うためにある。**
+
+型チェックはこのワークフローでは回さない（本体ソースの調達が要るぶん重い）ので、**リリースするコミットはCIが緑であること**を確認する。テストは依存が無く一瞬なのでワークフロー側で通している。
 
 ## ドキュメントの方針（SSOT）
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -93,8 +93,8 @@ feat: add resonance roll dialog
 
 ### 自動チェック
 
-- **pre-commitフック**: `npm install` 時に [lefthook](https://lefthook.dev/) がgitフックを自動セットアップし、コミット時にstagedファイルへBiomeが適用される（修正は自動でstageされる）。`.hbs` を触れば `check:templates`、`lang/*.json` を触れば `check:lang`、`package.json` / `biome.json` / `ci.yml` を触れば `check:biome-version` も走る。緊急時は `git commit --no-verify` でスキップできるが非推奨
-- **CI**: pushとPRで GitHub Actions が Biome・テスト・ビルド・型チェック・翻訳/テンプレート/スキーマ表/Biomeバージョンの整合チェックを実行する（`.github/workflows/ci.yml`）。マージにはCIが通ることが必要
+- **pre-commitフック**: `npm install` 時に [lefthook](https://lefthook.dev/) がgitフックを自動セットアップし、コミット時にstagedファイルへBiomeが適用される（修正は自動でstageされる）。`.hbs` を触れば `check:templates`、`lang/*.json` を触れば `check:lang`、`system.json` を触れば `check:manifest-urls`、`package.json` / `biome.json` / `ci.yml` を触れば `check:biome-version` も走る。緊急時は `git commit --no-verify` でスキップできるが非推奨
+- **CI**: pushとPRで GitHub Actions が Biome・テスト・ビルド・型チェック・翻訳/テンプレート/スキーマ表/配布URL/Biomeバージョンの整合チェックを実行する（`.github/workflows/ci.yml`）。マージにはCIが通ることが必要
   - 型チェックジョブは本体ソース（`client/` + `common/`）をActions cacheで保持し、キャッシュミス時のみ `tools/fetch-foundry.mjs` がsecrets（`FOUNDRY_USERNAME` / `FOUNDRY_PASSWORD`）でfoundryvtt.comからNode配布版を取得する。フォークからのPRでは実行されない
 - **依存の更新**: DependabotがnpmとGitHub Actionsを週次で見る（`.github/dependabot.yml`）。パッチとマイナーは1本にまとめ、メジャーは個別にPRが立つ。**Biomeだけは3箇所（`package.json` / `biome.json` の `$schema` / `ci.yml` の `setup-biome`）を揃える必要がある**。Dependabotが上げてくるのは `package.json` だけなので、残り2つは手で追従させる。揃っていなければ `check:biome-version` が落ちるので、追従漏れはDependabotのPRの時点で分かる
 
@@ -116,7 +116,7 @@ feat: add resonance roll dialog
 
 **Releaseとタグを作るのは人**で、`.github/workflows/release.yml` はビルドして `system.json` と `dist.zip` を添付するだけ。draw-steel / ryuutama と同じ形にしてある。
 
-1. `system.json` の `version` を更新する
+1. `system.json` の `version` と `download` を更新する（`download` は `releases/download/<version>/dist.zip`。揃っていなければ `check:manifest-urls` が落ちるので、直し忘れはコミットの時点で分かる）
 2. `npm run verify:live` を通す（[実機検証](/testing#実機検証)。CIでは回らないので、ここは人が確認する）
 3. `develop` から `main` へPRを出す。ワークフローがビルドと `dist.zip` の作成まで走らせ、成果物を artifact に残すので、**マージ前に中身を確認できる**。`version` が最新Releaseと同じままなら通知が出る（落としはしない。`main` はドキュメントサイトのデプロイ元でもあり、版を上げないマージも通常のため）
 4. マージする
@@ -128,6 +128,19 @@ feat: add resonance roll dialog
 タグと `system.json` の `version` が食い違っていたらワークフローが止まる。食い違ったまま配ると更新の検知が壊れるため。ただしその時点でReleaseは公開済みなので、直してタグごと作り直すことになる。**3の通知はこれを事前に拾うためにある。**
 
 型チェックはこのワークフローでは回さない（本体ソースの調達が要るぶん重い）ので、**リリースするコミットはCIが緑であること**を確認する。テストは依存が無く一瞬なのでワークフロー側で通している。
+
+### 配布URLの決まり（`manifest` と `download`）
+
+役割が違うので方式も違う。どちらも間違えても手元では何も起きず、配ったあとに壊れる。`npm run check:manifest-urls` が両方を機械で見ている。
+
+| フィールド | 値 | なぜ |
+|---|---|---|
+| `manifest` | `releases/latest/download/system.json`（**動くポインタ**） | Foundryが更新確認で引くのは、**インストール済みの** `system.json` に書いてある `manifest`。タグ固定にすると、そのバージョンを入れた人は同じ中身をいつまでも見ることになり、更新が永久に届かない |
+| `download` | `releases/download/<version>/dist.zip`（**タグ固定**） | zipのURLは**リモートのマニフェスト**から読まれる。両方 `latest` だと latest を別々に2回解決するので、そのあいだに新しいReleaseが出ると「古いマニフェストで新しいzipを入れる」がありうる |
+
+更新確認の実装は本体の `dist/packages/system.mjs` の `System#getUpdateNotification()` と、`dist/packages/views.mjs` の `installPackage()` にある。前者が `this.manifest` をfetchして `isNewerVersion` で比べ、後者が**リモート側の** `download` を `FileDownloader` に渡す。
+
+参考システムも `manifest` は全て動くポインタで、dnd5e は `raw.githubusercontent.com/.../master/system.json`、draw-steel と ryuutama は `latest`。タグ固定にしているものは1つも無い。
 
 ## ドキュメントの方針（SSOT）
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -14,6 +14,12 @@ pre-commit:
       glob: "*.hbs"
       run: npm run check:templates
 
+    # manifest / download のURLは間違えても手元では何も起きず、配ったあとに壊れる。
+    # version を上げて download を直し忘れるのが典型なので、コミットの時点で見る
+    - name: manifest-urls
+      glob: "system.json"
+      run: npm run check:manifest-urls
+
     # 上のbiomeジョブのglobがjsonを含むため、lang/を編集すると整形だけ走って
     # ja/enの整合はCIまで分からなかった。2ファイルを突き合わせるのでこちらも全体を見る
     - name: lang

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -20,6 +20,15 @@ pre-commit:
       glob: "lang/*.json"
       run: npm run check:lang
 
+    # Biomeのバージョンは3箇所に散っており、揃っていないとCIとローカルで違うBiomeが走る。
+    # Dependabotが上げてくるのは package.json だけなので、そのPRの時点で気付けるようにする
+    - name: biome-version
+      glob:
+        - "package.json"
+        - "biome.json"
+        - ".github/workflows/ci.yml"
+      run: npm run check:biome-version
+
 commit-msg:
   jobs:
     - name: message-format

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "check:lang": "node tools/check-lang.mjs",
     "check:templates": "node tools/check-templates.mjs",
     "check:schema-doc": "node tools/check-schema-doc.mjs",
+    "check:manifest-urls": "node tools/check-manifest-urls.mjs",
     "link:foundry": "node tools/create-symlinks.mjs",
     "typecheck": "node tools/typecheck.mjs",
     "verify:live": "node tests/live/run.mjs"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lint": "biome check .",
     "test": "vitest run",
     "prepare": "lefthook install",
+    "check:biome-version": "node tools/check-biome-version.mjs",
     "check:lang": "node tools/check-lang.mjs",
     "check:templates": "node tools/check-templates.mjs",
     "check:schema-doc": "node tools/check-schema-doc.mjs",

--- a/system.json
+++ b/system.json
@@ -47,6 +47,6 @@
   },
   "initiative": "@initiative",
   "manifest": "https://github.com/ryotai-trpg/emoklore/releases/latest/download/system.json",
-  "download": "https://github.com/ryotai-trpg/emoklore/releases/latest/download/dist.zip",
+  "download": "https://github.com/ryotai-trpg/emoklore/releases/download/0.0.2/dist.zip",
   "url": "https://github.com/ryotai-trpg/emoklore"
 }

--- a/tools/check-biome-version.mjs
+++ b/tools/check-biome-version.mjs
@@ -1,0 +1,73 @@
+// Biomeのバージョンが3箇所で揃っているかチェックする
+// （package.json / biome.json の $schema / ci.yml の setup-biome）
+//
+// プラグイン（tools/*.grit）を使う都合でバージョンを固定しているため、揃っていないと
+// CIとローカルで違うBiomeが走る。追従の手順は docs/contributing.md に書いてあるが、
+// Dependabotの更新で2回続けて漏れたので機械で見る
+import { readFileSync } from "node:fs";
+
+const PACKAGE_JSON = "package.json";
+const BIOME_JSON = "biome.json";
+const CI_YML = ".github/workflows/ci.yml";
+
+/** @type {{ where: string, version: string }[]} */
+const found = [];
+const problems = [];
+
+// 1. package.json の devDependencies
+const declared = JSON.parse(readFileSync(PACKAGE_JSON, "utf-8")).devDependencies?.[
+  "@biomejs/biome"
+];
+if (declared === undefined) {
+  problems.push(`${PACKAGE_JSON}: devDependencies に @biomejs/biome が無い`);
+} else if (!/^\d+\.\d+\.\d+$/.test(declared)) {
+  // ^ や ~ が付くと他の2箇所と一致していてもローカルだけ別のBiomeが入りうるので、
+  // 完全固定であること自体を検査する
+  problems.push(
+    `${PACKAGE_JSON}: @biomejs/biome は範囲指定ではなく完全固定にする（現在: ${declared}）`,
+  );
+} else {
+  found.push({ where: `${PACKAGE_JSON} の @biomejs/biome`, version: declared });
+}
+
+// 2. biome.json の $schema。バージョンはURLの一部なので抜き出す
+const schema = JSON.parse(readFileSync(BIOME_JSON, "utf-8")).$schema;
+const schemaVersion = /schemas\/(\d+\.\d+\.\d+)\//.exec(schema ?? "")?.[1];
+if (schemaVersion === undefined) {
+  problems.push(`${BIOME_JSON}: $schema からバージョンを読めない（現在: ${schema}）`);
+} else {
+  found.push({ where: `${BIOME_JSON} の $schema`, version: schemaVersion });
+}
+
+// 3. ci.yml の setup-biome。YAMLパーサを足さずに済ませたいので、`uses:` の行を見つけて
+// 次のステップ（`- ` で始まる行）に入るまでの `version:` を拾う
+const lines = readFileSync(CI_YML, "utf-8").split("\n");
+const stepIndex = lines.findIndex((line) => /^\s*-\s*uses:\s*biomejs\/setup-biome@/.test(line));
+if (stepIndex === -1) {
+  problems.push(`${CI_YML}: biomejs/setup-biome のステップが見つからない`);
+} else {
+  let ciVersion;
+  for (const line of lines.slice(stepIndex + 1)) {
+    if (/^\s*-\s/.test(line)) break;
+    const matched = /^\s*version:\s*["']?(\S+?)["']?\s*$/.exec(line);
+    if (matched) {
+      ciVersion = matched[1];
+      break;
+    }
+  }
+  if (ciVersion === undefined) problems.push(`${CI_YML}: setup-biome に version の指定が無い`);
+  else found.push({ where: `${CI_YML} の setup-biome`, version: ciVersion });
+}
+
+const versions = new Set(found.map(({ version }) => version));
+if (versions.size > 1) {
+  problems.push("3箇所のバージョンが揃っていない");
+  for (const { where, version } of found) problems.push(`  ${version}  ← ${where}`);
+}
+
+if (problems.length > 0) {
+  console.error("Biomeのバージョンが同期していない（追従の手順は docs/contributing.md）:");
+  for (const problem of problems) console.error(`  - ${problem}`);
+  process.exit(1);
+}
+console.log(`biome version OK: 3箇所とも ${[...versions][0]}`);

--- a/tools/check-manifest-urls.mjs
+++ b/tools/check-manifest-urls.mjs
@@ -1,0 +1,39 @@
+// system.json の manifest / download のURLが規約どおりかチェックする
+//
+// この2つは役割が違い、間違えても手元では何も起きず、配ったあとに壊れる。
+//
+// - manifest … Foundryが更新確認で毎回引くURL。**動くポインタでなければならない**。
+//   タグ固定にすると、そのバージョンを入れた人はいつまでも同じ中身を見ることになり、
+//   `isNewerVersion(remote.version, installed.version)` が永久に偽になって更新が届かない
+// - download … 更新を実行するときにzipを取るURL。**リモートのマニフェストのほう**が
+//   読まれる（本体の dist/packages/views.mjs の installPackage）。latest にすると
+//   マニフェストとzipで latest を別々に2回解決することになり、そのあいだに新しい
+//   Releaseが出ると「古いマニフェストで新しいzipを入れる」がありうる。タグに固定して
+//   version と揃えておけば、必ず同じRelease由来になる
+import { readFileSync } from "node:fs";
+
+const REPO = "https://github.com/ryotai-trpg/emoklore";
+
+const system = JSON.parse(readFileSync("system.json", "utf-8"));
+const { version, manifest, download } = system;
+
+const expectedManifest = `${REPO}/releases/latest/download/system.json`;
+const expectedDownload = `${REPO}/releases/download/${version}/dist.zip`;
+
+const problems = [];
+
+if (manifest !== expectedManifest) {
+  problems.push(`manifest が規約と違う\n      期待: ${expectedManifest}\n      実際: ${manifest}`);
+}
+if (download !== expectedDownload) {
+  problems.push(
+    `download が version (${version}) と揃っていない\n      期待: ${expectedDownload}\n      実際: ${download}`,
+  );
+}
+
+if (problems.length > 0) {
+  console.error("system.json の配布URLが規約と違う（リリース手順は docs/contributing.md）:");
+  for (const problem of problems) console.error(`  - ${problem}`);
+  process.exit(1);
+}
+console.log(`manifest urls OK: manifest は latest、download は ${version} 固定`);


### PR DESCRIPTION
Issue #55。PR #67 の上に積んでいるので base は `ci/biome-version-check`。#67 がマージされたら `develop` に付け替える。

## リリースの自動化

GitHubでReleaseをpublishすると `.github/workflows/release.yml` がビルドして `system.json` と `dist.zip` を添付する。**Releaseとタグを作るのは人**で、ワークフローは成果物を載せるだけ。

参考システム4本を読んで形を決めた。draw-steel と ryuutama が `release: types: [published]`、dnd5e がタグpush、pf2e が `workflow_dispatch`。**PRをトリガにしているものは1つも無かった。**

あわせて `main` 宛のPRでも同じビルドを回し、成果物を artifact に残す。`develop → main` が通常だが `hotfix → main` もありうるので、headではなくbaseで絞っている。マージ前に `dist.zip` の中身を確認でき、`version` が最新Releaseと同じままなら通知が出る。落としはしない。`main` はドキュメントサイトのデプロイ元でもあり、版を上げないマージも通常のため。

Release側ではタグと `system.json` の `version` を照合して食い違えば止める。その時点でReleaseは公開済みなので、PR側の通知が事前の関所になる。

zipは `dist/` ごと包まず中身を直下に入れる。Foundryはzip直下の `system.json` をまず探し、無ければ `*system.json` で終わるエントリを含むディレクトリをルートとみなして剥がす（本体の `dist/packages/installer.mjs`）。直下なら推測を挟まない。

publishしてから添付が終わるまでの数十秒は `releases/latest/download/` が404になる。下書きにアセットは載せられない（GitHubは下書きに対して `created` / `edited` / `deleted` でワークフローを起動しない）ので、この窓はこの形では消せない。手順書に明記した。

## 配布URLの方式

`manifest` と `download` はどちらも `latest` を指していたが、役割が違うので方式も違わなければならない。本体ソース（v14.365）で確定させた。

| | 経路 | 結論 |
|---|---|---|
| `manifest` | `System#getUpdateNotification()`（`dist/packages/system.mjs`）が**インストール済みの** `system.json` の `manifest` をfetchし、`isNewerVersion` で比べる | **動くポインタでなければならない。** タグ固定にすると更新が永久に届かない。`latest` のまま |
| `download` | `installPackage()`（`dist/packages/views.mjs`）が `let l = n.download` と、**リモートのマニフェスト側**の値を `FileDownloader` に渡す | **タグ固定にする。** 両方 `latest` だと latest を別々に2回解決し、そのあいだに新しいReleaseが出ると「古いマニフェストで新しいzipを入れる」がありうる |

参考システム4本とも `manifest` は動くポインタ（dnd5e は master ブランチのURL、draw-steel と ryuutama は `latest`）で、`download` はタグ固定。方式は揃っている。

`version` を上げて `download` を直し忘れるのが典型の事故なので `tools/check-manifest-urls.mjs` で機械検査する。`download` の期待値は `version` から導くので、真になる情報は `version` 1つ。CIの build ジョブ・pre-commit（`system.json` を触ったとき）・リリースワークフローの3箇所で通す。dnd5e は同じ検査をリリース時にしか持っていない。

`download` を空文字にする案（draw-steel / ryuutama がそうしている）は採らない。スキーマが `StringField({required: false, blank: false})` で、空文字は不正な値のため。

## 実走で確認したこと

使い捨てのブランチとタグで両方のトリガを通し、痕跡は消してある。

**main宛のPR** — Release専用の2ステップが skipped、PR専用の2ステップが実行。`##[notice]system.json の version は 0.0.99（最新Releaseは 0.0.2）`。artifact `dist` が 1,741,255 B・有効期限7日。

**Release publish**（`0.0.99` を prerelease で作成）— prerelease でも `published` が発火。checkout がタグを見ている（版の照合が通った）。`dist.zip` と `system.json` が添付された。**`releases/latest` は終始 `0.0.2` のまま。** zip直下に `system.json` が単独で、`__MACOSX` / `.DS_Store` はゼロ。

`check:manifest-urls` を足したのは実走のあとなので、リリースワークフロー内でのそのステップだけCIでの実行が未確認。ローカルでは正常系と3通りの壊し方（`version` だけ上げる・`download` を `latest` に戻す・`manifest` をタグ固定にする）を確認しており、`ci.yml` 側の同じスクリプトはこのPRのCIで走る。