### PR TITLE
npm run dev をHMR付きdevサーバに切り替える

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@
 
 ```shell
 npm install
-npm run dev         # vite build --watch（localhost:30001でFoundryにproxy）
+npm run dev         # 初回buildの後、HMR付きdevサーバ（localhost:30001でFoundryにproxy）
 npm run typecheck   # 型チェック（要 foundry/ symlink。セットアップ: docs/contributing.md）
 npm run docs:dev    # VitePressプレビュー
 npm run docs:build  # VitePressビルド

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -15,11 +15,12 @@
 git clone https://github.com/ryotai-trpg/emoklore.git
 cd emoklore
 npm install
-npm run dev   # vite build --watch
+npm run dev   # 初回build + HMR付きdevサーバ（localhost:30001）
 ```
 
-- FoundryVTT の `Data/systems/emoklore` に `dist/` を配置（またはsymlink）すると、ローカルのFoundryでシステムが読み込まれる
-- `vite.config.ts` のproxy設定により、Foundry本体（既定 `localhost:30000`、環境変数 `FOUNDRY_URL` で変更可）を起動した状態で `localhost:30001` を開くと、ビルド結果が反映された画面で開発できる
+- FoundryVTT の `Data/systems/emoklore` に `dist/` を配置（またはsymlink）すると、ローカルのFoundryでシステムが読み込まれる。devサーバを使うときも必要（Foundryサーバ本体が `system.json` とテンプレートをディスクから読むため）
+- Foundry本体（既定 `localhost:30000`、環境変数 `FOUNDRY_URL` で変更可）を起動した状態で `localhost:30001` を開くと、ソースから直接配信された画面で開発できる。CSSは保存で即時反映（HMR、リロード不要）、TS・テンプレート・言語ファイルは保存で自動フルリロードされる
+- `localhost:30000` を直接開いた場合は、最後に `npm run build` した内容が表示される（devサーバの変更は乗らない）。バンドルされた実物で確認したいときは `npm run watch`（旧来の `vite build --watch`）を使う
 
 ### 型チェック
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   },
   "scripts": {
     "build": "vite build",
-    "dev": "vite build --watch",
+    "dev": "vite build && vite dev",
+    "watch": "vite build --watch",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs",

--- a/tools/vite-plugin-foundry-dev.ts
+++ b/tools/vite-plugin-foundry-dev.ts
@@ -1,0 +1,94 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import type { Plugin } from "vite";
+
+// vite dev を Foundry へのproxy越しに使うための serve 専用プラグイン（Issue #52）。
+// Foundryが生成するHTMLは system.json に従って
+//   <script type="module" src="systems/emoklore/emoklore.mjs">
+//   @import "systems/emoklore/emoklore.css" layer(system)
+// を埋め込むが、devサーバにはどちらの実体も無いので、このプラグインが辻褄を合わせる。
+//
+// 前提: root直下に emoklore.mjs / emoklore.css を置かないこと。実在すると
+// vite:resolve が先に解決してしまい、ここでの差し替えが素通りされる。
+
+// vite が渡す id / URL のクエリ（?direct・?import・&t= 等）を落として比較する
+const stripQuery = (id: string): string => id.split("?")[0] ?? id;
+
+// Windows でも vite の id は / 区切りなので、比較用パスも / に揃える
+const normalize = (p: string): string => p.split(path.sep).join("/");
+
+export function foundryDev(): Plugin {
+  let root = "";
+  let base = "";
+  let entryTs = ""; // <root>/module/emoklore.ts
+  let cssIndex = ""; // <root>/css/emoklore.css
+
+  return {
+    name: "emoklore:foundry-dev",
+    apply: "serve",
+
+    configResolved(config) {
+      root = config.root;
+      base = config.base;
+      entryTs = normalize(path.resolve(root, "module/emoklore.ts"));
+      cssIndex = normalize(path.resolve(root, "css/emoklore.css"));
+    },
+
+    // HTMLが要求する /systems/emoklore/emoklore.mjs（base除去後 /emoklore.mjs）を
+    // TSエントリへマップする。以降のimport解決とTS変換はviteの標準処理が行う
+    resolveId(source) {
+      if (stripQuery(source) === "/emoklore.mjs") return entryTs;
+      return null;
+    },
+
+    // devではCSSがJSモジュール経由の <style> 注入になり、system.json の
+    // layer: "system" が効かず unlayered として最強になってしまう（モジュールの
+    // 上書きがdevでだけ効かない）。本番と同じカスケードにするため @layer system で包む。
+    // このtransformは vite:css（postcss-importによる @import インライン化）の後・
+    // vite:css-post（JS化）の前に走るので、受け取るcodeは展開済みの1枚のCSS。
+    // 制約: css/emoklore.css に外部URLの @import や @charset を書くと
+    // インライン化されずに残り、@layer ブロック内では無効になる（現状は相対のみ）
+    transform(code, id) {
+      if (stripQuery(id) === cssIndex) return { code: `@layer system{${code}}` };
+      return null;
+    },
+
+    configureServer(server) {
+      // HTML内の @import "systems/emoklore/emoklore.css" への応答。実CSSは上の
+      // transform経由でJS注入されるので、404ノイズと二重適用を防ぐ空スタブを返す。
+      // configureServerで登録したミドルウェアはproxy・base除去より前に走るため、
+      // ここはbase付きの生URLで照合する
+      const stubUrl = `${base}emoklore.css`;
+      server.middlewares.use((req, res, next) => {
+        if (req.url && stripQuery(req.url) === stubUrl) {
+          res.setHeader("Content-Type", "text/css");
+          res.end("/* dev: 実CSSは emoklore.mjs からJS経由で注入される */\n");
+          return;
+        }
+        next();
+      });
+    },
+
+    // テンプレートはHTTPではなく、Foundryサーバが socket 経由でディスク
+    // （Data/systems/emoklore = dist へのsymlink）から読む。viteは経路上に
+    // いないので、変更をdistへコピーして届け、フルリロードで反映する。
+    // lang はクライアントがHTTP取得し vite-plugin-static-copy のserveミドルウェアが
+    // ソースから直接配信するため、コピー不要でリロードだけでよい
+    async handleHotUpdate({ file, server }) {
+      const templatesDir = `${normalize(path.resolve(root, "templates"))}/`;
+      const langDir = `${normalize(path.resolve(root, "lang"))}/`;
+      if (file.startsWith(templatesDir) && file.endsWith(".hbs")) {
+        const dest = path.resolve(root, "dist", path.relative(root, file));
+        await fs.mkdir(path.dirname(dest), { recursive: true });
+        await fs.copyFile(file, dest);
+        server.ws.send({ type: "full-reload" });
+        return [];
+      }
+      if (file.startsWith(langDir) && file.endsWith(".json")) {
+        server.ws.send({ type: "full-reload" });
+        return [];
+      }
+      return undefined;
+    },
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,12 @@
       "@common/*": ["./foundry/common/*"]
     }
   },
-  "include": ["*.ts", "module/**/*", "foundry/client/global.d.mts", "foundry/common/global.d.mts"],
+  "include": [
+    "*.ts",
+    "module/**/*",
+    "tools/*.ts",
+    "foundry/client/global.d.mts",
+    "foundry/common/global.d.mts"
+  ],
   "exclude": ["node_modules", "dist"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from "vite";
 import { viteStaticCopy } from "vite-plugin-static-copy";
+import { foundryDev } from "./tools/vite-plugin-foundry-dev";
 
 // proxy先のFoundry本体。既定はメイン環境（30000）、検証環境に向ける場合は
 // FOUNDRY_URL=http://localhost:30014 のように上書きする
@@ -11,6 +12,9 @@ export default defineConfig({
   // open: "/",
   server: {
     port: 30001,
+    // handleHotUpdate が dist/templates へ書くので、distを監視から外して
+    // 自分の書き込みを自分のwatcherが拾い直すのを防ぐ
+    watch: { ignored: ["**/dist/**"] },
     proxy: {
       "^(?!/systems/emoklore)": foundryUrl,
       "/socket.io": {
@@ -38,6 +42,7 @@ export default defineConfig({
     },
   },
   plugins: [
+    foundryDev(),
     viteStaticCopy({
       // v4 はコピー元の相対パスを保つので、dest はすべて dist 直下（""）でよい。
       // v3 の `lang/*` + `dest: "lang"` は v4 では dist/lang/lang/ に二重に入る。


### PR DESCRIPTION
Issue #52 の項目1。`npm run dev` を `vite build --watch` から「初回build + vite dev」に切り替える。30001のserver設定はサーバが立たないため最初から死に設定だった。

serve専用プラグイン `tools/vite-plugin-foundry-dev.ts` を足した。エントリ `emoklore.mjs` へのリクエストをTSソースにマップし、devで注入されるCSSを `@layer system` で包んで本番とカスケードを一致させ、manifest由来の `emoklore.css` には空スタブを返し、`.hbs` 編集は dist へコピーしてフルリロードする。

`/@vite/client` の注入は不要だった。CSSのJSモジュール化コードが自らimportし、proxyの否定先読みがvite管轄に残すため自動で解決される。lang/assets のHTTP配信は vite-plugin-static-copy のserveモードが賄う。

実機で検証済み: proxy越しのログインとsocket.io疎通、CSS編集のリロードなし反映、`@layer modules` の競合ルールが勝つこと（Issueに書いた逆転の解消）、TS・hbs・lang編集の自動フルリロード、シート描画、verify:live 47件全通過。

旧フローは `npm run watch` として残した。CLAUDE.md と contributing.md の30001の記述も実態に合わせた。