### PR TITLE
表示していないCombatの更新でトラッカーが落ちるのを避ける

### DIFF
--- a/module/applications/combat-tracker.ts
+++ b/module/applications/combat-tracker.ts
@@ -12,6 +12,44 @@ const { CombatTracker } = foundry.applications.sidebar.tabs;
 const BAR_TEMPLATE = systemPath("templates/combat/initiative-bar.hbs");
 
 /**
+ * 描画オプション。本体は更新のたびに差分（`renderData`）を載せてくるが、
+ * `ApplicationRenderOptions` の型定義には無いので受け取る側で足す
+ * （`client/applications/_types.mjs:73-88`）。
+ */
+type RenderOptions = Parameters<InstanceType<typeof CombatTracker>["_onRender"]>[1] & {
+  renderData?: unknown;
+};
+
+/**
+ * 表示中のCombatに一致しない差分を落とす。**本体のバグ避け（#100）。本体が直るまで外さない。**
+ *
+ * 本体の `CombatTracker#_onRender` は `let data = {}` を置いたあと
+ * `if (Array.isArray(renderData)) data = renderData.find(d => d._id === this.viewed?.id)`
+ * で上書きし、見つからなくても `"turn" in data` を見る
+ * （v14.365 / `client/applications/sidebar/tabs/combat-tracker.mjs:184-188`）。
+ * 表示していないCombatが更新されると find が undefined を返して TypeError になる。
+ * 更新の render は await されないので、未処理のPromise拒否としてコンソールに出続ける。
+ *
+ * 配列でなくして渡せば本体は `data = {}` のまま進み、飛ぶのはアクティブなcombatantへの
+ * スクロール追従だけになる。**表示していないCombatの更新なので、追従すべきものが無い。**
+ * 一致する差分があるときは素通しするので、本来の追従は効いたままになる。
+ */
+const dropUnviewedRenderData = (
+  options: RenderOptions,
+  // 本体の `this.viewed?.id` と同じ値を受ける。表示中のCombatが無ければ null になり、
+  // どの差分にも一致しない（＝そのときこそ本体が落ちる）
+  viewedId: string | null | undefined,
+): RenderOptions => {
+  const { renderData } = options;
+  if (!Array.isArray(renderData)) return options;
+
+  const changes = renderData as ReadonlyArray<{ _id?: string }>;
+  if (changes.some((change) => change._id === viewedId)) return options;
+
+  return { ...options, renderData: undefined };
+};
+
+/**
  * イニシアチブ基準の選択バーを後付けする CombatTracker。
  *
  * 本体トラッカーはApplicationV2。PARTを差し替えず、_onRender でバーを注入する
@@ -21,9 +59,9 @@ const BAR_TEMPLATE = systemPath("templates/combat/initiative-bar.hbs");
 export class EmokloreCombatTracker extends CombatTracker {
   override async _onRender(
     context: Parameters<InstanceType<typeof CombatTracker>["_onRender"]>[0],
-    options: Parameters<InstanceType<typeof CombatTracker>["_onRender"]>[1],
+    options: RenderOptions,
   ): Promise<void> {
-    await super._onRender(context, options);
+    await super._onRender(context, dropUnviewedRenderData(options, this.viewed?.id));
     await this.#renderInitiativeBar();
   }
 

--- a/tests/live/checks/combat.mjs
+++ b/tests/live/checks/combat.mjs
@@ -101,6 +101,40 @@ export async function run({ page, check }) {
     }),
   );
 
+  // 本体の CombatTracker#_onRender は renderData.find が空振りしても `"turn" in data` を
+  // 見るので、表示していないCombatの更新で落ちる（#100）。差分を先に外して super へ渡している
+  await check("表示していないCombatの更新でトラッカーが落ちない", () =>
+    assertInPage(page, async () => {
+      const combat = await Combat.implementation.create({});
+      try {
+        await ui.combat.render({ force: true });
+        if (ui.combat.viewed?.id === combat.id) {
+          return {
+            ok: false,
+            detail: "作ったCombatが表示中になっていて、一致しない更新を作れない",
+          };
+        }
+
+        // 本体が update のときに載せてくるのと同じ形。実際の経路では render が await
+        // されないので未処理のPromise拒否になる。ここでは await して直接受ける
+        try {
+          await ui.combat.render({
+            parts: ["tracker"],
+            renderContext: "updateCombat",
+            // biome-ignore lint: 本体が差分に載せるIDのキーそのもの。改名すると再現しない
+            renderData: [{ _id: combat.id, round: 1 }],
+          });
+        } catch (err) {
+          return { ok: false, detail: `トラッカーの再描画が落ちた: ${err.message}` };
+        }
+
+        return { ok: true, detail: "表示中のCombatに一致しない差分でも再描画が通った" };
+      } finally {
+        await combat.delete();
+      }
+    }),
+  );
+
   await check("ラウンド終了で心肺停止者に生存リマインダが出て、ボタンで判定が飛ぶ", () =>
     assertInPage(
       page,


### PR DESCRIPTION
`npm run verify:live` が実行のたびに `TypeError: Cannot use 'in' operator to search for 'turn' in undefined` を4件拾って落ちていた。原因は本体側にあり、詳細は #100 に書いた。

本体の `CombatTracker#_onRender` は `let data = {}` を置いたあと `if (Array.isArray(renderData)) data = renderData.find(d => d._id === this.viewed?.id)` で上書きし、見つからなくても `"turn" in data` を見る（v14.365 / `client/applications/sidebar/tabs/combat-tracker.mjs:184-188`）。表示していないCombatが更新されると find が undefined を返して throw する。更新の render は await されないので、未処理のPromise拒否としてコンソールに出続ける。

`EmokloreCombatTracker._onRender` が super を呼ぶ前に、表示中のCombatに一致しない `renderData` を落とす。`Array.isArray` が false になれば本体は `data = {}` のまま進み、飛ぶのはアクティブなcombatantへのスクロール追従だけになる。そもそも表示していないCombatの更新なので追従すべきものが無く、一致する差分があるときは素通しするので本来の追従は効いたままになる。

渡す options は浅くコピーする。本体は同じオブジェクトを render フックにも回すので、元を書き換えるとフックの受け取る内容まで変わる。

実機検証に「表示していないCombatの更新でトラッカーが落ちない」を足した。本体が差分に載せるのと同じ形の options で `ui.combat.render` を await し、拒否を直接受ける。修正を外すと `トラッカーの再描画が落ちた: Cannot use 'in' operator to search for 'turn' in undefined` で赤くなることを確認した。

**実機検証が92件すべて通るようになった。** これまでは「コンソールエラーと警告通知が無い」が常に落ちる状態で、人が毎回読み分けていた。

本体のバグ避けなので、関数のコメントに「本体が直るまで外さない」と根拠ごと書いてある。#100 は本体への報告が残るので閉じない。
