### PR TITLE
角丸を役割ごとのトークンにまとめ、経歴タブを本体の stacked に寄せる

### DIFF
--- a/css/applications/character-sheet.css
+++ b/css/applications/character-sheet.css
@@ -112,26 +112,19 @@
     }
   }
 
-  /* 経歴タブの入力フォーム。本体の form-group を縦積みに寄せる */
+  /* 経歴タブの入力フォーム。
+     ラベルと入力の縦積みは本体の `.form-group.stacked` に任せる（`biography.hbs` の
+     `formGroup` が `stacked=true` を渡す）。以前はここで本体の `.form-group` を
+     `flex-direction` / `align-items` / `gap` の3つで打ち消し、さらに `.form-group.stacked`
+     を `row` に戻していた — 打ち消しの打ち消しになっていた */
   .tab.biography {
     div.flexrow {
-      gap: 20px;
+      gap: var(--spacer-16);
     }
 
-    .form-group {
-      display: flex;
-      flex-direction: column;
-      align-items: flex-start;
-      gap: 0px;
-    }
-
-    .form-group.stacked {
-      display: flex;
-      flex-direction: row;
-
-      .editor-container {
-        min-height: 150px;
-      }
+    /* 備考はリッチテキスト。本体の既定では潰れるので高さを与える */
+    .editor-container {
+      min-height: 150px;
     }
   }
 

--- a/css/applications/item-sheet.css
+++ b/css/applications/item-sheet.css
@@ -25,7 +25,7 @@
     width: 3rem;
     height: 3rem;
     border: none;
-    border-radius: 4px;
+    border-radius: var(--emoklore-box-radius);
     object-fit: cover;
   }
 

--- a/css/applications/kai-sheet.css
+++ b/css/applications/kai-sheet.css
@@ -29,7 +29,7 @@
     width: 3rem;
     height: 3rem;
     border: none;
-    border-radius: 4px;
+    border-radius: var(--emoklore-box-radius);
     object-fit: cover;
   }
 
@@ -94,7 +94,7 @@
   .em-kai__emotion {
     padding: 1px var(--spacer-8);
     border: 1px solid var(--color-border);
-    border-radius: 10px;
+    border-radius: var(--emoklore-box-radius);
     background: var(--color-data-background);
   }
 

--- a/css/applications/npc-sheet.css
+++ b/css/applications/npc-sheet.css
@@ -31,7 +31,7 @@
     width: 3rem;
     height: 3rem;
     border: none;
-    border-radius: 4px;
+    border-radius: var(--emoklore-box-radius);
     object-fit: cover;
   }
 

--- a/css/chat/weapon-card.css
+++ b/css/chat/weapon-card.css
@@ -36,7 +36,7 @@
   width: 2.25rem;
   height: 2.25rem;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--emoklore-box-radius);
   object-fit: cover;
 }
 

--- a/css/components/card.css
+++ b/css/components/card.css
@@ -5,11 +5,11 @@
     background: var(--emoklore-surface-sunken);
     display: flex;
     flex-direction: column;
-    border-radius: var(--emoklore-card-radius);
+    border-radius: var(--emoklore-panel-radius);
   }
 
   .em-card__image {
-    border-top-left-radius: var(--emoklore-card-radius);
-    border-top-right-radius: var(--emoklore-card-radius);
+    border-top-left-radius: var(--emoklore-panel-radius);
+    border-top-right-radius: var(--emoklore-panel-radius);
   }
 }

--- a/css/components/data-table.css
+++ b/css/components/data-table.css
@@ -28,7 +28,7 @@
     padding: 0;
     background: var(--emoklore-surface-sunken);
     font-weight: bold;
-    border-radius: 3px;
+    border-radius: var(--emoklore-box-radius);
   }
 
   .em-data-table__head > * {

--- a/css/components/sidebar.css
+++ b/css/components/sidebar.css
@@ -53,7 +53,7 @@
     /* 本体のボタンが持つ padding を残すと、border-box でも
        padding + border より細くならず幅が合わない */
     padding: 0;
-    border-radius: 0 4px 4px 0;
+    border-radius: 0 var(--emoklore-box-radius) var(--emoklore-box-radius) 0;
     font-size: var(--font-size-12);
     transition: transform 300ms ease;
   }

--- a/css/variables.css
+++ b/css/variables.css
@@ -13,6 +13,30 @@
    ダークでもない環境では body にテーマクラスを付けないため（client/game.mjs の
    #configureTheme）、テーマ別ブロックだけに色を置くと変数が未定義になる */
 
+/* --- 角丸 ---
+   **テーマで変わらないので `:root` に置く。** チャットカードは `.emoklore` の外に出る
+   ので（`css/chat/` は `.emoklore` スコープに入れない決まり）、`.emoklore` に置くと
+   カード側から引けない。引けない変数を書いても `border-radius` が無効になるだけで
+   何の警告も出ないため、スコープのほうを合わせる。
+
+   本体には角丸の変数が1つも無いので、寄せる先は生値の分布しかない
+   （4px:34箇所 / 3px:26 / 2px:16 / 5px:14 / 6px:12 / 8px:7 / 10px:4）。 */
+:root {
+  /* バーの端。高さ10pxの `.em-progress` を丸め切る半径で、分布に寄せる値ではない */
+  --emoklore-progress-radius: 5px;
+
+  /* 行に埋める背の低いバー・段入力。丸めすぎると段の区切りが読めなくなる */
+  --emoklore-progress-radius-small: 2px;
+
+  /* 小さい枠。画像の枠・表の見出し行・タグ・サイドバーのトグルが共有する。
+     本体の最頻値に合わせる */
+  --emoklore-box-radius: 4px;
+
+  /* 沈んだ大きい面（立ち絵カード）。小さい枠と同じ半径にすると、面積に対して
+     角が立って見える。丸みは面の大きさに対して決まるので、枠とは別に持つ */
+  --emoklore-panel-radius: 8px;
+}
+
 .emoklore {
   /* Layout */
   --emoklore-sheet-sidebar-width: 250px;
@@ -20,11 +44,6 @@
   /* 一覧の行に埋め込むコントロール（バー・段入力・アイコン枠）の高さ。
      行の高さがこれで決まるので、バーだけ・段だけを変えると揃わなくなる */
   --emoklore-row-control-size: 1.25rem;
-
-  /* Border Radius */
-  --emoklore-progress-radius: 5px;
-  --emoklore-progress-radius-small: 2px;
-  --emoklore-card-radius: 10px;
 
   /* --- ブランド ---
      青がエモクロアの主アクセント。橙はガイアケアの色で、用途が決まるまでは

--- a/docs/ui-design.md
+++ b/docs/ui-design.md
@@ -19,6 +19,10 @@ CSS・テンプレート・ダイアログの規約と、その背後にある�
 
 **部品に位置決めを書かない**。`grid-row` / `grid-column` / 外側の margin / 幅は、置く側（`applications/`）から modifier セレクタで指定する。これがあるのでNPCシートやアイテムシートを足したときに同じ部品をそのまま使える。
 
+### 変数を置くスコープ
+
+**テーマで変わる値は `.emoklore` に、変わらない値は `:root` に置く。** チャットカードは `.emoklore` の外に出るので、`.emoklore` に置いた変数はカード側から引けない。**引けない変数を書いても宣言が無効になるだけで、警告は何も出ない** — 角丸が0になって初めて気付くことになる。色はテーマ別ブロックが `.emoklore` を前提にしているのでそのまま、角丸のようにテーマと無関係な値は `:root` に置いて両方から引けるようにする。
+
 `system.json` の `styles` で `layer: "system"` を宣言する。本体は `foundry2.css` の冒頭で `reset, variables, elements, blocks, applications, compatibility, layouts, system, modules, exceptions` を宣言していて、`system` はシステム用に空けてある。`applications` より後なので本体には勝ち、`modules` には負ける。本体側は `@import "..." layer(system)` の形で読み込む（`templates/views/layouts/main.hbs`）ため、`css/emoklore.css` の中で `@layer` を書けば `system` の副レイヤになる。
 
 ## 寸法の決め方

--- a/templates/actor/biography.hbs
+++ b/templates/actor/biography.hbs
@@ -16,13 +16,14 @@
     {{/each}}
 
     {{else}}
+    {{! stacked はラベルを入力の上に積む本体の指定。自前のCSSで打ち消さずに済む }}
     <div class="flexrow">
       {{#each biographyPairedRows as |row|}}
-      {{formGroup row.field value=row.value}}
+      {{formGroup row.field value=row.value stacked=true}}
       {{/each}}
     </div>
     {{#each biographyRows as |row|}}
-    {{formGroup row.field value=row.value}}
+    {{formGroup row.field value=row.value stacked=true}}
     {{/each}}
     {{/if}}
   </div>

--- a/templates/actor/header.hbs
+++ b/templates/actor/header.hbs
@@ -43,8 +43,9 @@
         {{> "systems/emoklore/templates/actor/partials/emotion-rows.hbs" rows=emotionRows
       acquired=acquiredEmotionRows}}
       </div>
+      {{! 塗りは素の --emoklore-accent。HP/MPと違い共鳴には固有の意味色を持たせない }}
       <progress
-        class="em-progress em-progress--resonance"
+        class="em-progress"
         id="character-resonance"
         value="{{ system.resources.resonance.value }}"
         max="{{ system.resources.resonance.max }}"


### PR DESCRIPTION
#59 のうち、ヘッダと無関係な分を片付ける。ヘッダの中にある meter の単位と min-width は #83 の後に回す（`.em-meter*` を使うのは `header.hbs` / `meter.hbs` / `emotion-rows.hbs` だけで、4件とも作り直す範囲の中にあるため）。

## 角丸

本体には角丸のCSS変数が1つも無いので、寄せる先は生値の分布しかない（4px:34箇所 / 3px:26 / 2px:16 / 5px:14 / 6px:12 / 8px:7 / 10px:4）。

小さい枠（画像の枠・表の見出し行・感情タグ・サイドバーのトグル）は最頻値の4pxに揃えて `--emoklore-box-radius` を共有する。以前は変数側が10pxで、直書きの6箇所（4px系）のほうが本体に近いという逆転が起きていた。

立ち絵カードだけは別のトークンにする（`--emoklore-panel-radius: 8px`）。丸みは面の大きさに対して決まるので、大きい面と小さい枠を同じ半径にすると面積に対して角が立って見える。バーの2つ（5px / 2px）は据え置く。5pxは高さ10pxの `.em-progress` を丸め切る半径で、分布に寄せる対象ではない。

**トークンは `:root` に置く。** チャットカードは `.emoklore` の外に出るので、`.emoklore` に置くとカード側から引けない。引けない変数を書いても宣言が無効になるだけで警告は出ず、角丸が0になって初めて気付く。この決まりを `docs/ui-design.md` に足した。

## 経歴タブ

`formGroup` に `stacked=true` を渡してCSSを2ブロック削った。本体の `.form-group.stacked` は `flex-wrap` と子の `flex: 0 0 100%` で成立するので、`column` に倒すと壊れる。そのため「縦積みに倒す」→「stacked を row に戻す」という打ち消しの打ち消しになっていた。ラベルと入力の間に本体の8pxが入るぶん縦に伸びる。生の `gap: 20px` も `--spacer-16` に寄せた。

## ついでに

`em-progress--resonance` を消した。CSSに規則が無く素のアクセントに落ちていた死んだクラスで、#83 が「ヘッダを触るときに整理する」としていた分。

## 確認したこと

lint / typecheck / test 226件 / templates / i18n / lang / schema-doc / `npm run verify:live` 106件。`npm run shots:live` で前後を撮り、66枚を総当たりで比較した。変わったのは経歴タブ（閲覧・編集）、立ち絵カードの角、アイテムタブの見出し行、怪異の感情タグだけ。
