### PR TITLE
一般技能と基本技能の視覚言語を揃える

### DIFF
--- a/css/components/chip.css
+++ b/css/components/chip.css
@@ -30,7 +30,9 @@
     text-align: left;
   }
 
-  .em-chip__target {
-    font-variant-numeric: tabular-nums;
+  /* 技能行の名前と同じ太さにする。行とチップで密度は違ってよいが、
+     同じ「技能の名前」が場所によって違う書体で出るのは別物に見える */
+  .em-chip__name {
+    font-weight: 600;
   }
 }

--- a/css/components/skill-row.css
+++ b/css/components/skill-row.css
@@ -60,14 +60,10 @@
     min-width: 0;
   }
 
-  /* Lvから右は、列間の基本（4px）に足して要素ごとに間隔を持たせる */
-  .em-skill-row__target {
-    border: 1px solid;
-    border-radius: var(--emoklore-progress-radius-small);
-    padding: 0 var(--spacer-4);
+  /* Lvから右は、列間の基本（4px）に足して要素ごとに間隔を持たせる。
+     目標値の見た目そのものは components/target.css が持つ（チップと共有） */
+  .em-skill-row .em-target {
     margin-inline-start: var(--spacer-4);
-    text-align: center;
-    font-variant-numeric: tabular-nums;
   }
 
   .em-skill-row__stat {

--- a/css/components/target.css
+++ b/css/components/target.css
@@ -1,0 +1,18 @@
+/* 判定の目標値。技能の行にも基本技能のチップにも同じ形で入る。
+
+   置き場所を1つにしてあるのは、行とチップで枠・角丸・詰め方を手で一致させないため。
+   どちらかを変えたときにもう片方が黙って置き去りになるのを、共有で防ぐ。
+
+   外側の余白は持たない（置く側の責務）。行では列の間隔として、チップでは
+   flex の gap として、置く側がそれぞれ決める */
+
+.emoklore {
+  .em-target {
+    border: 1px solid;
+    border-radius: var(--emoklore-progress-radius-small);
+    padding: 0 var(--spacer-4);
+    text-align: center;
+    /* 桁が変わっても数字の位置がずれないようにする */
+    font-variant-numeric: tabular-nums;
+  }
+}

--- a/css/emoklore.css
+++ b/css/emoklore.css
@@ -13,6 +13,8 @@
 @import url("./components/sidebar.css");
 @import url("./components/emotion-list.css");
 @import url("./components/stat-row.css");
+/* 目標値は技能の行とチップが共有するので、両方より先に置く */
+@import url("./components/target.css");
 @import url("./components/skill-row.css");
 @import url("./components/chip.css");
 @import url("./components/field-list.css");

--- a/module/applications/context/character.ts
+++ b/module/applications/context/character.ts
@@ -22,7 +22,7 @@ import { prepareActiveEffectCategories } from "../../utils/effects";
 import { prepareHowlingRows } from "../../utils/howling";
 import { typedEntries } from "../../utils/object";
 import { enrichDocumentHTML } from "../../utils/sheet";
-import { describeSkill } from "../../utils/skill";
+import { describeSkill, SHEET_CONTEXT } from "../../utils/skill";
 import { formatDamagePreview, formatRangeLabel } from "../../utils/weapon";
 import {
   BIOGRAPHY_PAIRED_COUNT,
@@ -88,7 +88,12 @@ const buildSkills = (actor: CharacterActor): Record<string, SkillRow> =>
       return [
         key,
         {
-          ...describeSkill({ kind: "skill", key }, entry.characteristic),
+          // 分野は名前の一部として名乗る。組み立ては describeSkill が持つ
+          ...describeSkill(
+            { kind: "skill", key, specialization: entry.specialization },
+            entry.characteristic,
+            SHEET_CONTEXT,
+          ),
           field: actor.system.schema.getField(["skills", key]),
           isExtra: isExtra ?? false,
           level: entry.level,
@@ -105,7 +110,7 @@ const buildSkills = (actor: CharacterActor): Record<string, SkillRow> =>
 /** 基本技能の表示用データ。目標値と能力値はアクター側が正 */
 const buildBaseSkills = (actor: CharacterActor): BaseSkillRow[] =>
   typedEntries(actor.system.baseSkills).map(([key, { characteristic, target }]) => ({
-    ...describeSkill({ kind: "base", key }, characteristic),
+    ...describeSkill({ kind: "base", key }, characteristic, SHEET_CONTEXT),
     key,
     target,
   }));
@@ -129,6 +134,7 @@ const buildCustomSkills = (actor: CharacterActor): CustomSkillRow[] =>
       ...describeSkill(
         { kind: "custom", label: entry.label, isBase: entry.isBase, isExtra: entry.isExtra },
         entry.characteristic,
+        SHEET_CONTEXT,
       ),
       id,
       level: entry.level,

--- a/module/applications/npc-sheet.ts
+++ b/module/applications/npc-sheet.ts
@@ -4,7 +4,7 @@ import type { EmokloreActor } from "../documents/actor";
 import type { EmokloreItem } from "../documents/item";
 import { typedEntries } from "../utils/object";
 import { createDocumentData, resolveEmbeddedDocumentClass } from "../utils/sheet";
-import { describeSkill, describeSkillLabel } from "../utils/skill";
+import { describeSkill, describeSkillLabel, SHEET_CONTEXT } from "../utils/skill";
 import { formatDamagePreview, formatRangeLabel } from "../utils/weapon";
 import { EmokloreActorSheet } from "./actor-sheet";
 import type { EmokloreRenderOptions, NpcSheetContext } from "./types";
@@ -56,7 +56,7 @@ export class EmokloreNpcSheet extends EmokloreActorSheet {
     context.skills = typedEntries(CONFIG.EMOKLORE.skills).map(([key]) => {
       const entry = system.skills[key];
       return {
-        ...describeSkill({ kind: "skill", key }, entry.characteristic),
+        ...describeSkill({ kind: "skill", key }, entry.characteristic, SHEET_CONTEXT),
         key,
         rollType: "skill",
         level: entry.level,
@@ -71,7 +71,7 @@ export class EmokloreNpcSheet extends EmokloreActorSheet {
     }
 
     context.baseSkills = typedEntries(system.baseSkills).map(([key, entry]) => ({
-      ...describeSkill({ kind: "base", key }, entry.characteristic),
+      ...describeSkill({ kind: "base", key }, entry.characteristic, SHEET_CONTEXT),
       key,
       rollType: "base-skill",
       level: entry.level,
@@ -80,12 +80,15 @@ export class EmokloreNpcSheet extends EmokloreActorSheet {
     }));
 
     context.customSkills = Object.entries(system.customSkills).map(([id, entry]) => ({
-      ...describeSkillLabel({
-        kind: "custom",
-        label: entry.label,
-        isBase: entry.isBase,
-        isExtra: entry.isExtra,
-      }),
+      ...describeSkillLabel(
+        {
+          kind: "custom",
+          label: entry.label,
+          isBase: entry.isBase,
+          isExtra: entry.isExtra,
+        },
+        SHEET_CONTEXT,
+      ),
       id,
       level: entry.level,
       target: entry.target,

--- a/module/chat/roll-flavor.ts
+++ b/module/chat/roll-flavor.ts
@@ -9,9 +9,9 @@ import type { SkillRollContext } from "../data/character-like";
 import { describeSkillLabel } from "../utils/skill";
 
 /**
- * チャットの見出しに出す判定名を組み立てる。「＊格闘」「★技能：専門」など。
+ * チャットの見出しに出す判定名を組み立てる。「★技能：専門」など。
  *
- * 印の付け方は `describeSkillLabel` が決める。判定の文脈は組込・基本・カスタムの
+ * 印と分野の組み立ては `describeSkillLabel` が決める。判定の文脈は組込・基本・カスタムの
  * どれでも同じ形（表示名と区分）に均されているので、カスタムとして渡す。
  */
 export function formatSkillName({
@@ -20,10 +20,8 @@ export function formatSkillName({
   isExtra,
   specialization,
 }: SkillRollContext): string {
-  const { markedLabel } = describeSkillLabel({ kind: "custom", label, isBase, isExtra });
-  if (!specialization) return markedLabel;
-
-  return _loc("EMOKLORE.Format.specialization", { name: markedLabel, specialization });
+  return describeSkillLabel({ kind: "custom", label, isBase, isExtra, specialization })
+    .displayLabel;
 }
 
 /** チャットの見出し。判定の種類によらず「〈○○〉判定」の形にする */

--- a/module/utils/skill.ts
+++ b/module/utils/skill.ts
@@ -30,29 +30,69 @@ const MARKED_LABEL_FORMATS = {
 } as const;
 
 /**
+ * 名前が置かれる文脈。**印を付けるかどうかはここで変わる。**
+ *
+ * `standalone`（既定）は名前だけが出る場所 — チャットの見出し、カード、効果の適用先、
+ * 選択肢。区分を名前でしか示せないので、ルールブックと同じ `＊` / `★` を両方付ける。
+ *
+ * `grouped` はシート。基本技能はチップ列に、一般技能は行に分かれて置かれるので、
+ * **置き場所そのものが区分を伝えている**。`＊` は全件に付く冗長な印になるので落とす。
+ * `★` は一般技能の中でエクストラを区別するため、こちらでも付ける。
+ */
+export type LabelContext = "standalone" | "grouped";
+
+/** シートが名前を組み立てるときの文脈。呼ぶ側で綴らずこれを使う */
+export const SHEET_CONTEXT: LabelContext = "grouped";
+
+/**
  * 印つきの表示名を組み立てる。
  *
  * 直に呼ばず `describeSkillLabel` を通すこと。印を付けるかどうかの判断まで含めて
  * 1箇所にまとめてある。
  */
-const markLabel = (label: string, isBase: boolean, isExtra: boolean): string => {
-  if (isBase) return _loc(MARKED_LABEL_FORMATS.base, { name: label });
+const markLabel = (
+  label: string,
+  isBase: boolean,
+  isExtra: boolean,
+  context: LabelContext,
+): string => {
+  if (isBase) {
+    return context === "grouped" ? label : _loc(MARKED_LABEL_FORMATS.base, { name: label });
+  }
   if (isExtra) return _loc(MARKED_LABEL_FORMATS.extra, { name: label });
   return label;
 };
 
-/** どの技能を見せたいか。組込・基本は表から引き、カスタムは持っている値で名乗る */
+/**
+ * どの技能を見せたいか。組込・基本は表から引き、カスタムは持っている値で名乗る。
+ *
+ * 分野（特化）はアクター側の値なので、表から引ける組込技能でも渡してもらう。
+ * 基本技能は分野を持たない（`data/character-like.ts` の `baseSkills`）。
+ */
 export type SkillDescriptor =
-  | { kind: "skill"; key: SkillKey }
+  | { kind: "skill"; key: SkillKey; specialization?: string | undefined }
   | { kind: "base"; key: BaseSkillKey }
-  | { kind: "custom"; label: string; isBase: boolean; isExtra: boolean };
+  | {
+      kind: "custom";
+      label: string;
+      isBase: boolean;
+      isExtra: boolean;
+      specialization?: string | undefined;
+    };
 
-/** 技能の名前まわり */
+/**
+ * 技能の名前まわり。3つの形を持つのは、場所によって足せるものが違うため。
+ *
+ * 編集モードは分野が入力欄なので名前に含められず、閲覧モードは「専門知識：民俗学」まで
+ * 出したい。**どれを使うかはテンプレートが選ぶが、組み立て方はここが決める。**
+ */
 export type SkillLabel = {
-  /** 翻訳済みの表示名。印は含まない */
+  /** 翻訳済みの表示名。印も分野も含まない */
   label: string;
-  /** 印つきの表示名。表示に使うのは基本こちら */
+  /** 印つきの表示名。分野は含まない。編集モードの行はこれを使う */
   markedLabel: string;
+  /** 印と分野まで込みの表示名。閲覧で名乗るのはこれ */
+  displayLabel: string;
 };
 
 /**
@@ -64,19 +104,41 @@ export type SkillLabel = {
  * `CONFIG.EMOKLORE` の label は i18nInit の performPreLocalization で翻訳済みなので、
  * ここでは参照するだけでよい。
  */
-export const describeSkillLabel = (ref: SkillDescriptor): SkillLabel => resolveLabelParts(ref);
+export const describeSkillLabel = (
+  ref: SkillDescriptor,
+  context: LabelContext = "standalone",
+): SkillLabel => {
+  const { label, markedLabel } = resolveLabelParts(ref, context);
+  const specialization = ref.kind === "base" ? undefined : ref.specialization;
 
-const resolveLabelParts = (ref: SkillDescriptor): SkillLabel => {
+  return {
+    label,
+    markedLabel,
+    // 印は名前に付き、分野はその後ろに続く（「★技能：専門」）。分野まで含めてから
+    // 印を付けると、分野のほうが区分に掛かって見える
+    displayLabel: specialization
+      ? _loc("EMOKLORE.Format.specialization", { name: markedLabel, specialization })
+      : markedLabel,
+  };
+};
+
+const resolveLabelParts = (
+  ref: SkillDescriptor,
+  context: LabelContext,
+): Omit<SkillLabel, "displayLabel"> => {
   if (ref.kind === "custom") {
-    return { label: ref.label, markedLabel: markLabel(ref.label, ref.isBase, ref.isExtra) };
+    return {
+      label: ref.label,
+      markedLabel: markLabel(ref.label, ref.isBase, ref.isExtra, context),
+    };
   }
   if (ref.kind === "base") {
     const { label } = CONFIG.EMOKLORE.baseSkills[ref.key];
-    return { label, markedLabel: markLabel(label, true, false) };
+    return { label, markedLabel: markLabel(label, true, false, context) };
   }
 
   const { label, isExtra } = CONFIG.EMOKLORE.skills[ref.key];
-  return { label, markedLabel: markLabel(label, false, isExtra ?? false) };
+  return { label, markedLabel: markLabel(label, false, isExtra ?? false, context) };
 };
 
 /** 技能1行の見せ方。名前まわりに、判定に使う能力値の見せ方を足したもの */
@@ -97,11 +159,12 @@ export type SkillDisplay = SkillLabel & {
 export const describeSkill = (
   ref: SkillDescriptor,
   characteristic: CharacteristicKey,
+  context: LabelContext = "standalone",
 ): SkillDisplay => {
   const { label: characteristicLabel, fa } = CONFIG.EMOKLORE.characteristics[characteristic];
 
   return {
-    ...describeSkillLabel(ref),
+    ...describeSkillLabel(ref, context),
     characteristic,
     characteristicLabel,
     characteristicIcon: fa,

--- a/templates/actor/base-skills.hbs
+++ b/templates/actor/base-skills.hbs
@@ -9,8 +9,8 @@
     data-roll-type="base-skill"
     data-skill="{{baseSkill.key}}"
   >
-    {{baseSkill.label}}
-    <span class="em-chip__target">{{baseSkill.target}}</span>
+    <span class="em-chip__name">{{baseSkill.markedLabel}}</span>
+    <span class="em-target">{{baseSkill.target}}</span>
     <i class="em-chip__icon fa-solid {{baseSkill.characteristicIcon}}"></i>
   </button>
   {{/each}}
@@ -25,8 +25,8 @@
     data-roll-type="custom-skill"
     data-item-id="{{baseSkill.id}}"
   >
-    {{baseSkill.markedLabel}}
-    <span class="em-chip__target">{{baseSkill.target}}</span>
+    <span class="em-chip__name">{{baseSkill.markedLabel}}</span>
+    <span class="em-target">{{baseSkill.target}}</span>
     <i class="em-chip__icon fa-solid {{baseSkill.characteristicIcon}}"></i>
   </button>
   {{/each}}

--- a/templates/actor/partials/custom-skill-row-edit.hbs
+++ b/templates/actor/partials/custom-skill-row-edit.hbs
@@ -31,7 +31,7 @@
       clearTo=0}}
   {{/if}}
 
-  <span class="em-skill-row__target">{{skill.target}}</span>
+  <span class="em-target">{{skill.target}}</span>
 
   {{! 参照能力値が2つ以上あるものだけ選べる。スキーマの choices ではなく件数で決まるので
       formInput ではなく素の select を書く }}

--- a/templates/actor/partials/custom-skill-row-play.hbs
+++ b/templates/actor/partials/custom-skill-row-play.hbs
@@ -12,9 +12,9 @@
     data-action="roll"
     data-roll-type="custom-skill"
     data-item-id="{{skill.id}}"
-  >{{skill.markedLabel}}</a>
+  >{{skill.displayLabel}}</a>
   <span class="em-skill-row__level">{{localize "EMOKLORE.Format.level" level=skill.level}}</span>
   <progress class="em-progress em-progress--sm" value="{{skill.level}}" max="3"></progress>
-  <span class="em-skill-row__target">{{skill.target}}</span>
+  <span class="em-target">{{skill.target}}</span>
   <i class="em-skill-row__stat fa-solid {{skill.characteristicIcon}}"></i>
 </div>

--- a/templates/actor/partials/skill-row-edit.hbs
+++ b/templates/actor/partials/skill-row-edit.hbs
@@ -5,7 +5,8 @@
   @param key   技能のキー
 --}}
 <div class="em-skill-row em-skill-row--edit" data-skill="{{key}}">
-  <span class="em-skill-row__name">{{skill.label}}</span>
+  {{! 分野はこの行の入力欄が持つので、名前には含めない（displayLabel ではなく markedLabel） }}
+  <span class="em-skill-row__name">{{skill.markedLabel}}</span>
 
   {{! 分野は技能によって有無が変わる。列を保つため、無い技能でも枠だけ置く }}
   <span class="em-skill-row__spec">
@@ -23,7 +24,7 @@
     label=skill.label
     clearTo=0}}
 
-  <span class="em-skill-row__target">{{skill.target}}</span>
+  <span class="em-target">{{skill.target}}</span>
 
   {{#if skill.field.fields.characteristic.choices}}
   <span class="em-skill-row__stat">

--- a/templates/actor/partials/skill-row-play.hbs
+++ b/templates/actor/partials/skill-row-play.hbs
@@ -5,13 +5,15 @@
   @param key   技能のキー
 --}}
 <div class="em-skill-row" data-skill="{{key}}">
-  <a class="em-skill-row__name" data-action="roll" data-roll-type="skill" data-skill="{{key}}">
-    {{#if skill.specialization}}
-      {{localize "EMOKLORE.Format.specialization" name=skill.label specialization=skill.specialization}}
-    {{else}}{{skill.label}}{{/if}}
-  </a>
+  {{! 印も分野も displayLabel が持つ。カスタム技能の行と同じ名乗り方になる }}
+  <a
+    class="em-skill-row__name"
+    data-action="roll"
+    data-roll-type="skill"
+    data-skill="{{key}}"
+  >{{skill.displayLabel}}</a>
   <span class="em-skill-row__level">{{localize "EMOKLORE.Format.level" level=skill.level}}</span>
   <progress class="em-progress em-progress--sm" value="{{skill.level}}" max="3"></progress>
-  <span class="em-skill-row__target">{{skill.target}}</span>
+  <span class="em-target">{{skill.target}}</span>
   <i class="em-skill-row__stat fa-solid {{skill.characteristicIcon}}"></i>
 </div>


### PR DESCRIPTION
同じタブに、行（subgridのグリッド）とチップ（flex-wrapのボタン）という別の視覚言語が並んでいた。密度の差は情報量の差に由来するので残し、名乗り方だけを揃える。

## 目標値と書体

行とチップで別々だった目標値の見た目を `components/target.css` の `.em-target` に1本化した。行は枠付きの箱、チップは素の数字で、同じ「目標値」が場所によって別物に見えていた。枠・角丸・詰め方を2箇所に書き写さないため、共有する側を部品にする。位置決め（Lvから右の間隔）は行の側が持つ決まりどおり `skill-row.css` に残した。

チップの名前も行と同じ `font-weight: 600` にした。列位置は揃えない（チップをグリッドに載せると折り返しで詰める密度を失う）。

## 印（＊ / ★）

これまでは組込技能に印が付かず、カスタム技能だけに付いていた。同じ一覧の中で「カスタムかどうか」で表記が変わっていて、区分の印としては読めない状態だった。

`LabelContext` を足して、**印を付けるかどうかを置かれる文脈で決める**形にした。

- `standalone`（既定）はチャットの見出し・カード・効果の適用先・選択肢。名前だけで区分を示すしかないので、ルールブックと同じ ＊ / ★ を両方付ける
- `grouped` はシート。基本技能はチップ列、一般技能は行と**置き場所が区分を伝える**ので、＊ は全件に付く冗長な印になる。落として ★ だけ残す

これで組込のエクストラ技能（〈霊感〉〈強運〉）に ★ が付き、チップ列の ＊ は消える。NPCシートも区分ごとの見出しで分かれているので同じ規則を当てた（共鳴者シートだけ直すと、シートの中で表記が2種類になる）。

## 分野（特化）

合成を `describeSkillLabel` に寄せた。これまで閲覧の行だけがテンプレートで `Format.specialization` を掛けており、印を使う経路と排他だった。`markedLabel`（印のみ）と `displayLabel`（印＋分野）を分けて、分野が入力欄になる編集モードは前者、閲覧は後者を使う。`chat/roll-flavor.ts` の組み立ても消える。

## 確認したこと

lint / typecheck / test 226件 / templates / i18n / lang / schema-doc / `npm run verify:live` 106件。`npm run shots:live` で前後を撮り、66枚を総当たりで比較した。**チャットカードは1枚も変わっていない**（判定・武器・怪異の攻撃・判定要求・共鳴要求／結果・ハウリング抽選、ライト／ダークとも差分0）。＊ をシートの上だけで落とす、という意図がそのまま効いていることの裏付けになる。

## 残り

編集モードの段入力を閲覧のバーとどう対応付けるかは保留。#82 は開けたままにする。
