### PR TITLE
怪異の攻撃のラベルをスキーマから引く

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -408,9 +408,7 @@
       "kaiAttack": {
         "Judgment": "Judgment",
         "Damage": "Damage",
-        "Judgeless": "No roll · successes",
         "SuccessCount": "Successes",
-        "MpCost": "MP cost",
         "UnnamedAttack": "Attack"
       },
       "skillRequest": {

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -408,9 +408,7 @@
       "kaiAttack": {
         "Judgment": "判定",
         "Damage": "ダメージ",
-        "Judgeless": "判定なし・成功数",
         "SuccessCount": "成功数",
-        "MpCost": "消費MP",
         "UnnamedAttack": "攻撃"
       },
       "skillRequest": {

--- a/module/chat/kai-attack-card.ts
+++ b/module/chat/kai-attack-card.ts
@@ -6,11 +6,34 @@
  */
 
 import { systemPath } from "../constants";
+import { KaiDataModel } from "../data/kai";
 import type { KaiAttackCardState } from "../data/messages/kai-attack-card";
 import type { EmokloreActor } from "../documents/actor";
 import { createCardMessage } from "./message";
 
 const TEMPLATE = systemPath("templates/chat/kai-attack-card.hbs");
+
+/**
+ * 攻撃欄のラベル。
+ *
+ * 「判定なし」「消費MP」は**攻撃そのものの性質**なので、文字列はスキーマが持つ。
+ * カードも怪異シートも同じところから引く（以前はシートがカードの名前空間へ借りに
+ * 来ており、シートの文字列がチャットの側に置かれている状態だった）。
+ *
+ * ラベルは `i18nInit` の `localizeSchema` がスキーマに入れるので、ここでは読むだけでよい。
+ */
+const attackFieldLabels = (): { judgeless: string; mpCost: string } => {
+  // getField は DataField 止まりで fields に降りられず、DataField の型にも label が出ない。
+  // 要素のスキーマとして名乗り直す（context/character.ts の biography と同じ形）。
+  // キーを実際に読む2つに絞ると、有限キーの Record として undefined 無しで引ける
+  const { fields } = KaiDataModel.schema.getField(
+    "attacks.element",
+  ) as foundry.data.fields.SchemaField & {
+    fields: Record<"judgeless" | "mpCost", { label: string }>;
+  };
+
+  return { judgeless: fields.judgeless.label, mpCost: fields.mpCost.label };
+};
 
 /** カードに載るロール。judgeless なら判定が無く、ダメージ式が空ならダメージが無い */
 export type KaiAttackRolls = {
@@ -25,6 +48,7 @@ export async function renderKaiAttackCard(
 ): Promise<string> {
   return foundry.applications.handlebars.renderTemplate(TEMPLATE, {
     ...state,
+    attackLabels: attackFieldLabels(),
     canApplyDamage: state.damageTotal !== null,
     judgmentHTML: judgmentRoll ? await judgmentRoll.render() : "",
     damageHTML: damageRoll ? await damageRoll.render() : "",

--- a/templates/actor/kai-sheet.hbs
+++ b/templates/actor/kai-sheet.hbs
@@ -132,15 +132,17 @@
           <a class="em-kai__attack-name" data-action="rollAttack">
             {{#if name}}{{name}}{{else}}{{localize "EMOKLORE.ChatMessage.kaiAttack.UnnamedAttack"}}{{/if}}
           </a>
+          {{! ラベルはスキーマから引く（attackFields）。攻撃の性質なので、
+              チャットカードと同じところを見る }}
           <span class="em-kai__attack-judge">
             {{#if judgeless}}
-              {{localize "EMOKLORE.ChatMessage.kaiAttack.Judgeless"}} {{fixedSuccess}}
+              {{@root.attackFields.judgeless.label}} {{fixedSuccess}}
             {{else}}
               {{diceCount}}DM≦{{target}}
             {{/if}}
           </span>
           {{#if damage}}<span class="em-kai__attack-damage">{{damage}}</span>{{/if}}
-          {{#if mpCost}}<span class="em-kai__attack-mp">{{localize "EMOKLORE.ChatMessage.kaiAttack.MpCost"}}{{mpCost}}</span>{{/if}}
+          {{#if mpCost}}<span class="em-kai__attack-mp">{{@root.attackFields.mpCost.label}}{{mpCost}}</span>{{/if}}
         {{else}}
           {{! ラベルとプレースホルダはスキーマから引く（コンテキストの attackFields）。
               name 属性だけは添字が要るのでここで組み立てる }}

--- a/templates/chat/kai-attack-card.hbs
+++ b/templates/chat/kai-attack-card.hbs
@@ -2,16 +2,18 @@
 <div class="em-kai-attack-card">
   <header class="em-kai-attack-card__head">
     <div class="em-kai-attack-card__name">{{attackName}}</div>
+    {{! 「判定なし」と「消費MP」は攻撃の性質なのでスキーマのラベルを引く（attackLabels）。
+        判定なしのときも成功数は固定値として出るので、両方を / 区切りで並べる }}
     <div class="em-kai-attack-card__meta">
       {{#if judgeless}}
-        {{localize "EMOKLORE.ChatMessage.kaiAttack.Judgeless"}}
+        {{attackLabels.judgeless}}
         <span class="em-kai-attack-card__sep">/</span>
       {{/if}}
       {{localize "EMOKLORE.ChatMessage.kaiAttack.SuccessCount"}}
       {{successCount}}
       {{#if mpCost}}
         <span class="em-kai-attack-card__sep">/</span>
-        {{localize "EMOKLORE.ChatMessage.kaiAttack.MpCost"}}
+        {{attackLabels.mpCost}}
         {{mpCost}}
       {{/if}}
     </div>


### PR DESCRIPTION
判定なしの攻撃カードが「判定なし・成功数 / 成功数 3」と、成功数を2回出していた。`ChatMessage.kaiAttack.Judgeless` の値が「判定なし・成功数」で、直後に `SuccessCount`（「成功数」）が続くため。

「判定なし」と「消費MP」は**攻撃そのものの性質**なので、文字列はスキーマが持つ。カードも怪異シートも `FIELDS.attacks.element.{judgeless,mpCost}.label` を引く形にした。これまでは逆に、シートがチャットカードの名前空間へ借りに来ていた（issue が「キーの置き場所としては筋が悪い」としていた分）。

表示はカードが「判定なし / 成功数 3」、シートが「判定なし 3」になる。カードは `/` 区切りで項目を並べる作りなので、判定の有無と成功数を別の項目として並べる。

借り手が居なくなった `ChatMessage.kaiAttack.Judgeless` と `.MpCost` は消す。`check:i18n` の「どこからも参照されないキー」検査が通っている。

## 気になっている点（このPRの範囲外）

怪異シートの表示が「沈降 **判定なし 3　2**」となり、固定成功数の3とダメージの2が裸の数字で並ぶ。ダメージ式が定数のときだけ起きる読みにくさで、攻撃行のレイアウト自体の問題。別途Issueにするか、シート側だけ「成功数」を添えるかは未決。

## 確認したこと

lint / typecheck / test 226件 / templates / i18n / lang / schema-doc / `npm run verify:live` 106件。`npm run shots:live` で前後を撮り、66枚を総当たりで比較した。変わったのは怪異の攻撃カード（判定なし）と怪異シートだけで、判定ありのカードは差分0。

Closes #110
