### PR TITLE
FoundryVTT 14.366 対応

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # ローカルのFoundry本体を更新したら合わせて上げる（世代はsystem.jsonのcompatibilityと対応）
-      FOUNDRY_BUILD: "365"
+      FOUNDRY_BUILD: "366"
       # フォークPRとDependabotのPRにはsecretsが渡らない（Dependabotは専用のsecret storeを見る）。
       # secretsコンテキストは if: から読めないので、有無だけをここに写して判定に使う
       HAS_CREDENTIALS: ${{ secrets.FOUNDRY_USERNAME != '' }}

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -94,6 +94,31 @@ cp .env.example .env   # git管理外。書いた項目だけが効く
 
    セットアップ画面に入るための管理者アクセスキーは、この初回起動の画面で設定する（未設定でも入れる。検証自体はワールドへの参加しかしないのでどちらでもよい）
 
+### 本体を更新したあと
+
+**本体のビルドを上げると、次の `verify:live` は必ず一度落ちる。** 症状は「joinページにユーザーが1人もいない」で、原因が本体更新だと分からない出方をするので先に書いておく。
+
+ワールドの `compatibility.verified` はビルド単位（例: `14.365`）で記録される。本体が 14.366 になると `World#canAutoLaunch` が偽になり、`--world` を付けても起動しない。
+
+```js
+// dist/packages/world.mjs
+get canAutoLaunch(){
+  if(this.availability === PACKAGE_AVAILABILITY_CODES.MISSING_SYSTEM) return false;
+  if(this.incompatibleWithCoreVersion) return false;
+  const e = this.compatibility.verified;
+  return !!e && (Number.isInteger(Number(e)) ? e >= release.generation
+                                             : !isNewerVersion(release.version, e));
+}
+```
+
+対処は**セットアップ画面からワールドを一度手で起動する**こと。`verified` が新しいビルドに更新され、以後は `--world` で起動できる。
+
+```shell
+node <FOUNDRY_APP>/main.mjs --dataPath=<FVTT_DEV_DATA> --port=30014
+```
+
+合わせて `.github/workflows/ci.yml` の `FOUNDRY_BUILD` も上げる（キャッシュキーがここから作られる）。
+
 ### 構成
 
 ```

--- a/tests/live/lib/foundry.mjs
+++ b/tests/live/lib/foundry.mjs
@@ -73,24 +73,23 @@ export async function startFoundry() {
 export async function joinAsUser(page) {
   await page.nav(`${ORIGIN}/join`);
 
-  const users = await page.eval(() =>
-    [...document.querySelectorAll("select[name=userid] option")]
-      .map((o) => [o.value, o.textContent.trim()])
-      .filter(([v]) => v),
-  );
-  const match = users.find(([, name]) => name === USER) ?? users[0];
-  if (!match) throw new Error("joinページにユーザーが1人もいない");
+  // 14.366でユーザー選択が <select name=userid> の一覧から <input name=username> の
+  // 自由入力（typeahead）に変わり、候補がDOMに載らなくなった。一覧から選べないので
+  // 名前を直接入れる。実在しない名前を入れても即座には弾かれず、game.ready に
+  // ならないまま下のループが尽きる形になる
+  const hasField = await page.eval(() => !!document.querySelector("input[name=username]"));
+  if (!hasField) throw new Error("joinページにユーザー名の入力欄が無い");
 
-  await page.eval((id) => {
-    const s = document.querySelector("select[name=userid]");
-    s.value = id;
-    s.dispatchEvent(new Event("change", { bubbles: true }));
+  await page.eval((name) => {
+    const input = document.querySelector("input[name=username]");
+    input.value = name;
+    input.dispatchEvent(new Event("change", { bubbles: true }));
     document.querySelector("button[name=join]").click();
-  }, match[0]);
+  }, USER);
 
   for (let i = 0; i < 200; i++) {
-    if (await page.eval(() => globalThis.game?.ready === true)) return match[1];
+    if (await page.eval(() => globalThis.game?.ready === true)) return USER;
     await new Promise((r) => setTimeout(r, 200));
   }
-  throw new Error(`${USER} でログインしたが game.ready にならない`);
+  throw new Error(`${USER} でログインできない（その名前のユーザーが無いか、アクセスキーが要る）`);
 }


### PR DESCRIPTION
本体を 14.366（2026-08-14, stable）へ更新し、型チェックと実機検証を通した。CIが参照するビルドも合わせる。

## joinフォームの変更に追従する

14.366 で join ページのユーザー選択が変わった。

```hbs
<!-- templates/setup/parts/join-form.hbs -->
<input type="text" name="username" id="join-username" value="{{preselected.name}}">
```

`<select name="userid">` + `<option>` の一覧が、`<input name="username">` の自由入力（typeahead）になった。実DOMを見たところ `datalist` もカスタム要素も無く、**候補がDOMに一切載らない**。一覧から選ぶ実装のままでは候補ゼロになり、`verify:live` が着手前に「joinページにユーザーが1人もいない」で止まる。

名前を直接入れる形に変えた。一覧が無いので「最初のユーザーに倒す」フォールバックは無くなり、名前が違うときはタイムアウトとして出る。エラーメッセージをそれに合わせた。

## 本体更新後の落とし穴を書く

**本体のビルドを上げると、次の `verify:live` は必ず一度落ちる。** ワールドの `compatibility.verified` がビルド単位（`14.365`）で記録されるため、`World#canAutoLaunch` が偽になり `--world` での起動が拒否される。出るメッセージは「joinページにユーザーが1人もいない」だけで、原因が本体更新だと分からない。

セットアップ画面から一度手で起動すれば `verified` が更新されて解消する。症状・原因・対処と、判断している本体のコードを `docs/testing.md` に書いた。

なお今回の更新で `minimum` が `"14.365"` から `"14"`（世代単位）に変わったので、次のビルド更新ではこの詰まりは起きにくくなる。

## 確認したこと

- 本体は 14.366.0（build 366）。`client/` と `common/` に 365 の残骸ファイルは0件（未来時刻のプローブで計測器の妥当性も確認済み）
- `npm run typecheck` 通過
- `npm run verify:live` **133件すべて通過**
- 特に見たかった2件は影響なし。14607（`messageMode` と吹き出しの条件変更）→ ダメージ結果の公開範囲をDLだけに絞る挙動は維持。14624（RollTableのDraw Result）→ ハウリング・共鳴表まわりは通過
- 失敗経路も実測した。存在しないユーザー名（`FVTT_USER=__no_such_user__`）で回すと、即座に弾かれるのではなくタイムアウトし、新しいエラーメッセージが出ることを確認（`docs/testing.md` の「チェックが本当に落ちるかを確かめる」に倣った）

## 補足

Issue #100（本体の `CombatTracker` が `renderData` の取り違えでコンソールエラー）は **14.366 でも直っていない**。リリースノートに CombatTracker の記載は無い。

`verify:live` が join に失敗すると、後始末が `game` の無いページで走って `TypeError: Cannot read properties of undefined (reading 'contents')` を出し、「手で消すこと」と表示する。**実際には検証データが作られる前に止まっているので消すものは無い。** 今回の変更とは無関係の既存挙動なので触っていない。別途直す。
