### PR TITLE
auditを定期実行に乗せ、後始末の誤報をなくす

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches: [develop, main]
   pull_request:
-  # typecheckジョブのキャッシュ延命を兼ねる。Actions cacheは7日アクセスが無いと
-  # 消えるので週2回触る。消えるとフォーク・DependabotのPRが型チェックを飛ばすようになる。
-  # 併せて develop が今も型チェックを通ることの定期確認になる
+  # 定期実行で回すのは typecheck と audit の2つ。
+  # typecheck: Actions cacheは7日アクセスが無いと消えるので週2回触って延命する。
+  #   消えるとフォーク・DependabotのPRが型チェックを飛ばすようになる。
+  #   併せて develop が今も型チェックを通ることの定期確認になる
+  # audit: 勧告は依存を触らなくても後から公開されるので、PRが立つのを待つと気付くのが遅れる
   schedule:
     - cron: "0 21 * * 1,4" # 月・木 06:00 JST
 
@@ -70,10 +72,11 @@ jobs:
       - name: Build docs
         run: npm run docs:build
 
+  # scheduleでも回す。勧告は依存を触らなくても後から公開されるので、PRが立つのを
+  # 待っていると気付くのが遅れる（nanoidのhighが3週間見過ごされた）
   audit:
     name: Audit
     runs-on: ubuntu-latest
-    if: github.event_name != 'schedule'
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7

--- a/tests/live/run.mjs
+++ b/tests/live/run.mjs
@@ -101,11 +101,19 @@ try {
   console.error(`\n検証が中断した: ${error.message}`);
 } finally {
   if (page) {
-    try {
-      const removed = await removeFixtures(page);
-      log(`\n検証用データを削除: ${removed.join(", ") || "なし"}`);
-    } catch (error) {
-      console.error(`検証用データの後始末に失敗した（手で消すこと）: ${error.message}`);
+    // ゲームに入る前に落ちた場合、検証データはまだ1件も作られていない。removeFixtures は
+    // game を読むので必ず失敗するが、消すものが無いので「手で消すこと」は誤報になる。
+    // 入れたかどうかで分ける
+    const joined = await page.eval(() => globalThis.game?.ready === true).catch(() => false);
+    if (!joined) {
+      log("\nゲームに入れていないので検証データは作られていない（後始末なし）");
+    } else {
+      try {
+        const removed = await removeFixtures(page);
+        log(`\n検証用データを削除: ${removed.join(", ") || "なし"}`);
+      } catch (error) {
+        console.error(`検証用データの後始末に失敗した（手で消すこと）: ${error.message}`);
+      }
     }
     page.close();
   }


### PR DESCRIPTION
CIまわりで見つかっていた小さい穴を2つ塞ぐ。どちらも独立している。

## auditを定期実行に乗せる

勧告は**依存を触らなくても後から公開される**ので、PRが立つのを待っていると気付くのが遅れる。実際、nanoid の high（GHSA-2v37-7h3g-55p8）は3週間 develop を赤いままにしていたのに、無関係なPRを立てて初めて表面化した。

`typecheck` を週2回のscheduleで回しているので、そこに相乗りさせる。閾値（`--audit-level=high`）や `dependencies` が空である前提は変えていない。

## 後始末の誤報をなくす

ゲームに入る前に `verify:live` が落ちると、検証データは1件も作られていないのに、こう表示していた。

```
検証用データの後始末に失敗した（手で消すこと）: TypeError: Cannot read properties of undefined (reading 'contents')
```

`removeFixtures` が `game.actors.contents` を読むため、ゲームに入れていなければ必ず `TypeError` になる。それを「後始末に失敗した」として報告していたが、**消すものは無い**ので誤報。しかも「手で消すこと」と言われた人は存在しないデータを探すことになる。

ゲームに入れたかどうかで分け、入れていないときは後始末が不要であることを言う。

## 確認したこと

失敗経路と正常系の両方を実測した。

**ゲームに入れないケース**（`FVTT_USER=__no_such_user__`）

```
検証が中断した: __no_such_user__ でログインできない（その名前のユーザーが無いか、アクセスキーが要る）

ゲームに入れていないので検証データは作られていない（後始末なし）
```

**正常系** — `npm run verify:live` 133件すべて通過。後始末も従来どおり動く。

```
検証用データを削除: __verify_char, __verify_target, __verify_import, __verify_npc, __verify_kai, __verify_scene
```

`npx biome ci .` と `ci.yml` のYAMLパースも通している。
